### PR TITLE
Fix for a test that fails in Linux (and other case sensitive environments).

### DIFF
--- a/src/test/java/com/tagtraum/perf/gcviewer/imp/TestDataReaderSun1_6_0G1.java
+++ b/src/test/java/com/tagtraum/perf/gcviewer/imp/TestDataReaderSun1_6_0G1.java
@@ -255,7 +255,7 @@ public class TestDataReaderSun1_6_0G1 extends TestCase {
         IMP_LOGGER.addHandler(handler);
         DATA_READER_FACTORY_LOGGER.addHandler(handler);
         
-        final InputStream in = getClass().getResourceAsStream("SampleSun1_7_0G1_Young.txt");
+        final InputStream in = getClass().getResourceAsStream("SampleSun1_7_0G1_young.txt");
         final DataReader reader = new DataReaderSun1_6_0G1(in);
         GCModel model = reader.read();
         


### PR DESCRIPTION
The text file is actually named "SampleSun1_7_0G1_young.txt" but in the test it was with a capital "Y".

This made the test fail in case sensitive environment (Linux).
