### PR TITLE
GCEvent export format fix

### DIFF
--- a/src/main/java/com/tagtraum/perf/gcviewer/model/GCEvent.java
+++ b/src/main/java/com/tagtraum/perf/gcviewer/model/GCEvent.java
@@ -144,6 +144,7 @@ public class GCEvent extends AbstractGCEvent<GCEvent> {
             for (GCEvent event : details) {
                 event.toStringBuffer(sb);
             }
+            sb.append(' ');
         }
         sb.append(preUsed);
         sb.append("K->");


### PR DESCRIPTION
Please pull this branch for a simple fix of (now closed) Issue #31. I have tested the output (of Sun JDK 1.6 CMS+ParNew) files generated for HP Jmeter Console and after inserting the blank it works.

Signed-off-by: Bernd Eckenfels bernd@eckenfels.net
