### PR TITLE
Support decimals for zoom factor

### DIFF
--- a/src/main/java/com/tagtraum/perf/gcviewer/action/Zoom.java
+++ b/src/main/java/com/tagtraum/perf/gcviewer/action/Zoom.java
@@ -33,7 +33,7 @@ public class Zoom extends AbstractAction {
         try {
             String item = (String)o[0];
             if (item.endsWith("%")) item = item.substring(0, item.length()-1);
-            final int zoomFactor = NumberParser.parseInt(item.trim());
+            final double zoomFactor = Double.parseDouble(item.trim());
             if (zoomFactor > 0) gcViewer.getSelectedGCDocument().getModelChart().setScaleFactor(zoomFactor/1000.0);
         }
         catch (NumberFormatException nfe) {


### PR DESCRIPTION
To get the chart fit on my screen I need 2.3%, this simple fix allows it. I also wonder if we can get rid of the NumberFormat parsers.
