### PR TITLE
Don't use localization when writing events with SimpleGcWriter

### DIFF
--- a/src/main/java/com/tagtraum/perf/gcviewer/exp/impl/SimpleGcWriter.java
+++ b/src/main/java/com/tagtraum/perf/gcviewer/exp/impl/SimpleGcWriter.java
@@ -35,12 +35,12 @@ public class SimpleGcWriter extends AbstractDataWriter {
     @Override
     public void write(GCModel model) throws IOException {
         Iterator<AbstractGCEvent<?>> i = model.getEvents();
+        final Locale NO_LOCALE = null;
         while (i.hasNext()) {
             AbstractGCEvent<?> abstractEvent = i.next();
             if (abstractEvent.isStopTheWorld()) {
                 GCEvent event = (GCEvent)abstractEvent;
-                out.printf((Locale)null, "%s %f %f", getSimpleType(event), event.getTimestamp(), event.getPause());
-                out.println();
+                out.printf(NO_LOCALE, "%s %f %f%n", getSimpleType(event), event.getTimestamp(), event.getPause());
             }
         }
 


### PR DESCRIPTION
PrintWriter.printf() uses the default locale of the system for formatting unless a locale is specified.
This affects e.g. numbers in locales that uses a comma instead of a period as decimal separator (and causes a failure in SimpleGcWriterTest when run on a system with Swedish locale).
The fix is to supply null as the locale since this will format without localization (according to the Javadoc for PrintWriter.printf()).
