### PR TITLE
Topic ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ jdk:
 
 branches:
   only:
-    - topic-travis
+    - master
 
 notifications:
   email:
-    - bernd-2012@eckenfels.net
+    - gcviewer-info@googlegroups.com


### PR DESCRIPTION
Jörg, did you consider to use CI for all commits? Here is my travis file. Failed builds will be sent From: Travis-CI notifications@travis-ci.org. I used the google groups address.

I havent been able to extract the build results from travis easily, but having verification builds is valuable even if you dont have those snapshots available.
