### PR TITLE
Automatic CI builds and gh-pages publishing  with travis 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: java
 script: mvn -q clean install
 jdk:
-  - oraclejdk6
+  - oraclejdk7
+  - openjdk6
+  - openjdk7
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ jdk:
 
 branches:
   only:
-    - topic-travis
+    - master
 
 notifications:
   email:
-    - bernd-2012@eckenfels.net
+    - gcviewer-info@googlegroups.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,9 @@ env:
   global:
       - secure: "L8/g6MW2BguawcrEVOZXjzSazJDu/iiZZ8KcH6EIaWyCpmS+FRZ0uw03QGVn\nrsDcbGe20cqSd+ZlWnE6VZ8MFv+q07xH2uJjzuyM1jnhm7+VpIAGVuAYFPsm\n4BgcyXS0ffx3FWtImrCRaKc9n/IV1soO9de+uoQY+YDxvOQzDY8="
 
-script: mvn clean package
+install: mvn --version
+
+script: mvn -q clean package
 
 jdk:
   - openjdk7
@@ -17,6 +19,6 @@ notifications:
   email:
     - bernd-2013@eckenfels.net
 
-after_script:
-  - mvn com.github.github:site-maven-plugin:site
+after_success:
+  - mvn -q com.github.github:site-maven-plugin:site
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,22 @@
 language: java
-script: mvn -q clean install
+
+env:
+  global:
+      - secure: "L8/g6MW2BguawcrEVOZXjzSazJDu/iiZZ8KcH6EIaWyCpmS+FRZ0uw03QGVn\nrsDcbGe20cqSd+ZlWnE6VZ8MFv+q07xH2uJjzuyM1jnhm7+VpIAGVuAYFPsm\n4BgcyXS0ffx3FWtImrCRaKc9n/IV1soO9de+uoQY+YDxvOQzDY8="
+
+script: mvn clean package
+
 jdk:
-  - oraclejdk7
-  - openjdk6
   - openjdk7
 
 branches:
   only:
-    - master
+    - topic-ciupload
 
 notifications:
   email:
-    - gcviewer-info@googlegroups.com
+    - bernd-2013@eckenfels.net
+
+after_script:
+  - mvn com.github.github:site-maven-plugin:site
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,29 @@
 language: java
 
+# define the $TOKEN environment variable with OAuth2 Token for GitHub
 env:
   global:
       - secure: "L8/g6MW2BguawcrEVOZXjzSazJDu/iiZZ8KcH6EIaWyCpmS+FRZ0uw03QGVn\nrsDcbGe20cqSd+ZlWnE6VZ8MFv+q07xH2uJjzuyM1jnhm7+VpIAGVuAYFPsm\n4BgcyXS0ffx3FWtImrCRaKc9n/IV1soO9de+uoQY+YDxvOQzDY8="
 
+# No need to run mvn install, so we use this step to print env details instead
 install: mvn --version
 
-script: mvn -q clean package
+# the package phase is all we need. deploy/install is skipped
+script: mvn -q clean verify
 
 jdk:
   - openjdk7
 
 branches:
   only:
+    - master
     - topic-ciupload
 
 notifications:
   email:
     - bernd-2013@eckenfels.net
 
+# Use the github site plugin to push the results to the gh-pages branch
 after_success:
   - mvn -q com.github.github:site-maven-plugin:site
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: java
+script: mvn -q clean install
+jdk:
+  - oraclejdk6
+
+branches:
+  only:
+    - topic-travis
+
+notifications:
+  email:
+    - bernd-2012@eckenfels.net

--- a/pom.xml
+++ b/pom.xml
@@ -1,11 +1,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
+
 	<groupId>com.tagtraum</groupId>
 	<artifactId>gcviewer</artifactId>
 	<version>1.32-SNAPSHOT</version>
+
 	<packaging>jar</packaging>
 	<name>GCViewer</name>
+
 	<url>http://github.com/chewiebug/GCViewer/wiki</url>
 
 	<developers>
@@ -85,6 +88,11 @@
 			<plugins>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-surefire-plugin</artifactId>
+					<version>2.10</version>
+				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-compiler-plugin</artifactId>
 					<version>2.3.2</version>
 					<configuration>
@@ -109,8 +117,8 @@
 				</plugin>
 				<plugin>
 					<groupId>com.github.github</groupId>
-					<artifactId>downloads-maven-plugin</artifactId>
-					<version>0.6</version>
+					<artifactId>site-maven-plugin</artifactId>
+					<version>0.7</version>
 				</plugin>
 			</plugins>
 		</pluginManagement>
@@ -120,7 +128,6 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.10</version>
 				<configuration>
 					<includes>
 						<include>com/tagtraum/perf/gcviewer/TestAll.java</include>
@@ -269,7 +276,6 @@
 			<plugin>
 				<groupId>com.github.github</groupId>
 				<artifactId>site-maven-plugin</artifactId>
-				<version>0.7</version>
 				<configuration>
 					<message>Travis #${env.TRAVIS_JOB_ID} build ${project.name} ${project.version}</message>
 					<outputDirectory>${project.build.directory}</outputDirectory>
@@ -280,7 +286,6 @@
 					<dryRun>false</dryRun>
 				</configuration>
 			</plugin>
-
 		</plugins>
 	</build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -58,17 +58,17 @@
 	</licenses>
 
 	<properties>
-		<github.global.server>github</github.global.server>
 
 		<build.timestamp>${maven.build.timestamp}</build.timestamp>
-
 		<maven.build.timestamp.format>yyyy-MM-dd HH:mm</maven.build.timestamp.format>
+
+        <github.global.oauth2Token>${env.TOKEN}</github.global.oauth2Token>
 	</properties>
 
 	<scm>
-		<url>https://github.com/chewiebug/GCViewer</url>
-		<connection>scm:git:git://https://github.com/chewiebug/GCViewer.git</connection>
-		<developerConnection>scm:git:git@github.com/chewiebug/GCViewer.git</developerConnection>
+		<url>https://github.com/ecki/GCViewer</url>
+		<connection>scm:git:git://https://github.com/ecki/GCViewer.git</connection>
+		<developerConnection>scm:git:git@github.com/ecki/GCViewer.git</developerConnection>
 	</scm>
 
 	<dependencies>
@@ -264,24 +264,23 @@
 				</executions>
 			</plugin>
 
-			<!-- execute this using "mvn install ghDownloads:upload" DON'T use eclipse 
-				to do so, because m2eclipse can't filter ${maven.build.timestamp} into build.info.properties -->
+			<!--  can be executed by travis-ci with "mvn com.github.github:site-maven-plugin:site"
+			      will require OAuth token for the github repo from scm.url in ${env.TOKEN}. -->
 			<plugin>
 				<groupId>com.github.github</groupId>
-				<artifactId>downloads-maven-plugin</artifactId>
+				<artifactId>site-maven-plugin</artifactId>
+				<version>0.7</version>
 				<configuration>
-					<description>${project.version} release of ${project.name}. This is
-						a development release of the latest sources. See
-						https://github.com/chewiebug/GCViewer/wiki/Changelog</description>
+					<message>Travis #${env.TRAVIS_JOB_ID} build ${project.name} ${project.version}</message>
+					<outputDirectory>${project.build.directory}</outputDirectory>
 					<includes>
 						<include>gcviewer_mac_${project.version}.zip</include>
 						<include>gcviewer-${project.version}.zip</include>
 					</includes>
-					<override>true</override>
-					<includeAttached>true</includeAttached>
 					<dryRun>false</dryRun>
 				</configuration>
 			</plugin>
+
 		</plugins>
 	</build>
 </project>


### PR DESCRIPTION
As discussed, this change allows travis to build snapshots and publish them to the GitHub pages branch. (You will need to adjust email, scm.urls, encrypted token and branch)

To apply it locally it us best to use this form (path)

https://github.com/ecki/GCViewer/compare/topic-ciupload.patch