### PR TITLE
Only draw ruler ticks within the current clip region

### DIFF
--- a/src/main/java/com/tagtraum/perf/gcviewer/ModelChartImpl.java
+++ b/src/main/java/com/tagtraum/perf/gcviewer/ModelChartImpl.java
@@ -556,7 +556,7 @@ public class ModelChartImpl extends JScrollPane implements ModelChart, ChangeLis
                 }
             } else {
                 double halfLineDistance = lineDistance / 2.0d;
-                double start = clip.x - (clip.x % lineDistance);
+                double start = clip.x - ((clip.x + offset * getPixelsPerUnit()) % lineDistance);
                 double end = clip.x + clip.width;
                 for (double line = start; line < end; line += lineDistance) {
                     g.drawLine((int) line, 0, (int) line, getHeight());


### PR DESCRIPTION
In Java 8, items drawn outside the horizontal ruler's clip region were showing up overlapping the numbers that should be shown. 

It looks like this could be a bug in Swing, but the workaround is reasonable. This should also be faster, since it's doing less work.

Example screenshot: (only 10m should be visible in the horizontal ruler)
![bad-ruler](https://cloud.githubusercontent.com/assets/374898/3959949/73774dd4-2736-11e4-9f24-040b44e87efc.png)
