### PR TITLE
Command line graph generation random issue

### DIFF
--- a/src/main/java/com/tagtraum/perf/gcviewer/SimpleChartRenderer.java
+++ b/src/main/java/com/tagtraum/perf/gcviewer/SimpleChartRenderer.java
@@ -4,40 +4,51 @@ import com.tagtraum.perf.gcviewer.model.GCModel;
 
 import javax.imageio.ImageIO;
 import javax.swing.*;
+
 import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 public class SimpleChartRenderer {
     private static final Logger LOGGER = Logger.getLogger(SimpleChartRenderer.class.getName());
 
-    public void render(GCModel model, String chartFilePath) throws IOException {
-        GCPreferences gcPreferences = new GCPreferences();
+    public void render(final GCModel model, String chartFilePath) throws IOException {
+        final GCPreferences gcPreferences = new GCPreferences();
         gcPreferences.load();
+        final Dimension d = new Dimension(gcPreferences.getWindowWidth(), gcPreferences.getWindowHeight());
 
-        final ModelChartImpl pane = new ModelChartImpl();
-        pane.setHorizontalScrollBarPolicy(JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
 
-        pane.setModel(model, gcPreferences);
-        pane.setFootprint(model.getFootprint());
-        pane.setMaxPause(model.getPause().getMax());
-        pane.setRunningTime(model.getRunningTime());
-
-        Dimension d = new Dimension(gcPreferences.getWindowWidth(), gcPreferences.getWindowHeight());
-        pane.setSize(d);
-        pane.addNotify();
-        pane.validate();
-
-        pane.autoSetScaleFactor();
-
-        final BufferedImage image = new BufferedImage(d.width, d.height, BufferedImage.TYPE_INT_RGB);
+        BufferedImage image = new BufferedImage(d.width, d.height, BufferedImage.TYPE_INT_RGB);
         final Graphics2D graphics = image.createGraphics();
         graphics.setBackground(Color.WHITE);
         graphics.clearRect(0, 0, image.getWidth(), image.getHeight());
+        try {
+			SwingUtilities.invokeAndWait(new Runnable() {
+				@Override
+				public void run() {
+			        ModelChartImpl pane = new ModelChartImpl();
+			        pane.setHorizontalScrollBarPolicy(JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
 
-        pane.paint(graphics);
+			        pane.setModel(model, gcPreferences);
+			        pane.setFootprint(model.getFootprint());
+			        pane.setMaxPause(model.getPause().getMax());
+			        pane.setRunningTime(model.getRunningTime());
+
+			        pane.setSize(d);
+			        pane.addNotify();
+			        pane.validate();
+
+			        pane.autoSetScaleFactor();
+			        pane.paint(graphics);
+				}
+			});
+		} catch (Exception e) {
+			LOGGER.log(Level.SEVERE, "Failed to paint graphic", e);
+		}
+
 
         ImageIO.write(image, "png", new File(chartFilePath));
     }


### PR DESCRIPTION
The command line graph generation might fail due to a concurrency issue.
The SimpleChartRenderer is called by 'main' thread, it creates a
ModelChartImpl, initialize it and validates. And calls setScaleFactor
that calls repaint (suspicious). For some reason when paint is called on
the BufferedImage I get an half-drawn graph.
To be sure in any case, I rather do any swing call within the
EventDispatchThread