### PR TITLE
Remove unused import, which causes build failure when JavaFX is not available

### DIFF
--- a/src/main/java/com/tagtraum/perf/gcviewer/SimpleChartRenderer.java
+++ b/src/main/java/com/tagtraum/perf/gcviewer/SimpleChartRenderer.java
@@ -16,7 +16,6 @@ import javax.swing.JScrollPane;
 import javax.swing.SwingUtilities;
 
 import com.tagtraum.perf.gcviewer.model.GCModel;
-import javafx.scene.chart.Chart;
 
 public class SimpleChartRenderer {
     private static final Logger LOGGER = Logger.getLogger(SimpleChartRenderer.class.getName());


### PR DESCRIPTION
There is an unused import, which causes a build failure when you do not have JavaFX available.