### PR TITLE
add min and max full GC pause to summary output

### DIFF
--- a/src/main/java/com/tagtraum/perf/gcviewer/exp/impl/SummaryDataWriter.java
+++ b/src/main/java/com/tagtraum/perf/gcviewer/exp/impl/SummaryDataWriter.java
@@ -204,6 +204,8 @@ public class SummaryDataWriter extends AbstractDataWriter {
                 exportValue(out, "avgFullGCPauseIsSig", isSignificant(model.getFullGCPause().average(), model.getFullGCPause().standardDeviation()));
                 exportValue(out, "avgFullGCPause", pauseFormatter.format(model.getFullGCPause().average()), "s");
                 exportValue(out, "avgFullGCPause\u03c3", pauseFormatter.format(model.getFullGCPause().standardDeviation()), "s");
+                exportValue(out, "minFullGCPause", pauseFormatter.format(model.getFullGCPause().getMin()), "s");
+                exportValue(out, "maxFullGCPause", pauseFormatter.format(model.getFullGCPause().getMax()), "s");
             }
             else {
                 exportValue(out, "avgFullGCPause", "n.a.", "s");


### PR DESCRIPTION
Hi.  Thank you for maintaining this utility - it's very useful.  This pull request exports two additional values when GCViewer is run in summary mode:  minFullGCPause and maxFullGCPause.