### PR TITLE
Fix a problem with quotes for language=fr

### DIFF
--- a/src/main/java/com/tagtraum/perf/gcviewer/imp/DataReaderFacade.java
+++ b/src/main/java/com/tagtraum/perf/gcviewer/imp/DataReaderFacade.java
@@ -138,7 +138,7 @@ public class DataReaderFacade {
      */
     private void showErrorDialog(final URL url, TextAreaLogHandler textAreaLogHandler, final Component parent) {
         final JPanel panel = new JPanel(new BorderLayout());
-        final JLabel messageLabel = new JLabel(new MessageFormat(LocalisationHelper.getString("datareader_parseerror_dialog_message")).format(new Object[]{textAreaLogHandler.getErrorCount(), url}));
+        final JLabel messageLabel = new JLabel(LocalisationHelper.getString("datareader_parseerror_dialog_message", textAreaLogHandler.getErrorCount(), url));
         messageLabel.setBorder(BorderFactory.createEmptyBorder(5, 0, 5, 0));
         panel.add(messageLabel, BorderLayout.NORTH);
         final JScrollPane textAreaScrollPane = new JScrollPane(textAreaLogHandler.getTextArea());
@@ -146,7 +146,7 @@ public class DataReaderFacade {
         panel.add(textAreaScrollPane, BorderLayout.CENTER);
         SwingUtilities.invokeLater(new Runnable(){
             public void run() {
-                JOptionPane.showMessageDialog(parent, panel, new MessageFormat(LocalisationHelper.getString("datareader_parseerror_dialog_title")).format(new Object[]{url}), JOptionPane.ERROR_MESSAGE);
+                JOptionPane.showMessageDialog(parent, panel, LocalisationHelper.getString("datareader_parseerror_dialog_title", url), JOptionPane.ERROR_MESSAGE);
             }
         });
     }

--- a/src/main/resources/com/tagtraum/perf/gcviewer/localStrings_fr.properties
+++ b/src/main/resources/com/tagtraum/perf/gcviewer/localStrings_fr.properties
@@ -29,13 +29,13 @@ data_panel_avg_pause = Pause moy
 
 data_panel_avg_pause_interval = fr Avg pause interval
 
-data_panel_avgfreedmemorybyfullgc = M\u00E9m lib moy GC complet
+data_panel_avgfreedmemorybyfullgc = M\u00e9m lib moy GC complet
 
 data_panel_avgfreedmemorybygc = Lib moy GC
 
-data_panel_avgrelativepostfullgcincrease = Accr rel moy apr\u00E8s GC complet
+data_panel_avgrelativepostfullgcincrease = Accr rel moy apr\u00e8s GC complet
 
-data_panel_avgrelativepostgcincrease = Accr rel moy apr\u00E8s GC
+data_panel_avgrelativepostgcincrease = Accr rel moy apr\u00e8s GC
 
 data_panel_count_full_gc_pauses = f Number of full gc pauses
 
@@ -61,25 +61,25 @@ data_panel_details_sum_percent = f sum (%)
 
 data_panel_details_total = f total
 
-data_panel_footprintafterconcgc_avg = Moy apr\u00E8s GC simultan\u00E9e
+data_panel_footprintafterconcgc_avg = Moy apr\u00e8s GC simultan\u00e9e
 
-data_panel_footprintafterconcgc_max = Max apr\u00E8s GC simultan\u00E9e
+data_panel_footprintafterconcgc_max = Max apr\u00e8s GC simultan\u00e9e
 
-data_panel_footprintafterfullgc_avg = Moy apr\u00E8s GC complet
+data_panel_footprintafterfullgc_avg = Moy apr\u00e8s GC complet
 
-data_panel_footprintafterfullgc_max = Max apr\u00E8s GC complet
+data_panel_footprintafterfullgc_max = Max apr\u00e8s GC complet
 
-data_panel_footprintaftergc_avg = Moy apr\u00E8s GC
+data_panel_footprintaftergc_avg = Moy apr\u00e8s GC
 
-data_panel_freedmemory = M\u00E9moire lib\u00E9r\u00E9e
+data_panel_freedmemory = M\u00e9moire lib\u00e9r\u00e9e
 
-data_panel_freedmemorybyfullgc = M\u00E9m lib par GC complet
+data_panel_freedmemorybyfullgc = M\u00e9m lib par GC complet
 
 data_panel_freedmemorybygc = Lib tot par GC
 
-data_panel_freedmemorypermin = M\u00E9m lib/Min
+data_panel_freedmemorypermin = M\u00e9m lib/Min
 
-data_panel_group_concurrent_gc_events = GCs simultan\u00E9es
+data_panel_group_concurrent_gc_events = GCs simultan\u00e9es
 
 data_panel_group_full_gc_pauses = f Full gc pauses
 
@@ -121,35 +121,35 @@ data_panel_tab_chart = f Chart
 
 data_panel_tab_details = f Event details
 
-data_panel_tab_memory = M\u00E9moire
+data_panel_tab_memory = M\u00e9moire
 
 data_panel_tab_pause = Pause
 
-data_panel_tab_summary = Synth\u00E8se
+data_panel_tab_summary = Synth\u00e8se
 
-data_panel_tenuredafterconcgc_avg = Moy ancienne apr\u00E8s GC simultan\u00E9e
+data_panel_tenuredafterconcgc_avg = Moy ancienne apr\u00e8s GC simultan\u00e9e
 
-data_panel_tenuredafterconcgc_max = Max ancienne apr\u00E8s GC simultan\u00E9e
+data_panel_tenuredafterconcgc_max = Max ancienne apr\u00e8s GC simultan\u00e9e
 
 data_panel_throughput = Throughput
 
-data_panel_total_time = dur\u00E9e totale
+data_panel_total_time = dur\u00e9e totale
 
 data_panel_vm_op_overhead = fr VM Operation Overhead
 
-datareader_parseerror_dialog_message = L'analyse syntaxique effectu\u00E9e par GCViewer a rencontr\u00E9 {0} probl\u00E8mes "{1}":
+datareader_parseerror_dialog_message = L''analyse syntaxique effectu\u00e9e par GCViewer a rencontr\u00e9 {0} probl\u00e8me(s) "{1}":
 
-datareader_parseerror_dialog_title = Probl\u00E8mes durant l'analyse du journal {0}
+datareader_parseerror_dialog_title = Probl\u00e8mes durant l''analyse du journal {0}
 
-datareaderfactory_instantiation_failed = La reconnaissance du format du journal a \u00E9chou\u00E9.
+datareaderfactory_instantiation_failed = La reconnaissance du format du journal a \u00e9chou\u00e9.
 
-datawriterfactory_instantiation_failed = Le format du journal n'est pas support\u00E9 :
+datawriterfactory_instantiation_failed = Le format du journal n''est pas support\u00e9 :
 
-fileexport_dialog_confirm_overwrite = Le fichier existe. L'\u00E9craser?
+fileexport_dialog_confirm_overwrite = Le fichier existe. L''\u00e9craser?
 
-fileexport_dialog_csv = Donn\u00E9es s\u00E9par\u00E9es par des virgules (*.csv)
+fileexport_dialog_csv = Donn\u00e9es s\u00e9par\u00e9es par des virgules (*.csv)
 
-fileexport_dialog_csv_ts = Donn\u00E9es s\u00E9par\u00E9es par des virgules avec estampe chronologique format unix (*.csv)
+fileexport_dialog_csv_ts = Donn\u00e9es s\u00e9par\u00e9es par des virgules avec estampe chronologique format unix (*.csv)
 
 fileexport_dialog_error_occured = Une erreur est survenue.
 
@@ -159,15 +159,15 @@ fileexport_dialog_summarylog = f Summary GC Log (*.csv)
 
 fileexport_dialog_title = Exporter le journal
 
-fileexport_dialog_txt = Donn\u00E9es textes (*.txt)
+fileexport_dialog_txt = Donn\u00e9es textes (*.txt)
 
-fileexport_dialog_write_file_failed = Impossible d'\u00E9crire le fichier.
+fileexport_dialog_write_file_failed = Impossible d''\u00e9crire le fichier.
 
-fileopen_dialog_add_checkbox = <html>Ajouter un journal<br>\u00E0 la fen\u00EAtre<br>courante.</html>
+fileopen_dialog_add_checkbox = <html>Ajouter un journal<br>\u00e0 la fen\u00eatre<br>courante.</html>
 
-fileopen_dialog_hint_add_checkbox = <html>Si coch\u00E9, le nouveau journal sera ajout\u00E9<br>\u00E0 la fen\u00EAtre courante, au lieu d'\u00EAtre ouvert dans une nouvelle fen\u00EAtre.</html>
+fileopen_dialog_hint_add_checkbox = <html>Si coch\u00e9, le nouveau journal sera ajout\u00e9<br>\u00e0 la fen\u00eatre courante, au lieu d''\u00eatre ouvert dans une nouvelle fen\u00eatre.</html>
 
-fileopen_dialog_read_file_failed = La lecture du journal a echou\u00E9.
+fileopen_dialog_read_file_failed = La lecture du journal a echou\u00e9.
 
 fileopen_dialog_title = Choisir le journal du GC
 
@@ -185,7 +185,7 @@ main_frame_menu_mnemonic_window = F
 
 main_frame_menu_view = Voir
 
-main_frame_menu_window = Fen\u00EAtre
+main_frame_menu_window = Fen\u00eatre
 
 main_frame_menuitem_about = A propos de GCViewer
 
@@ -193,9 +193,9 @@ main_frame_menuitem_add_file = Ajouter une vue
 
 main_frame_menuitem_antialias = Lissage
 
-main_frame_menuitem_arrange = R\u00E9organiser
+main_frame_menuitem_arrange = R\u00e9organiser
 
-main_frame_menuitem_concurrent_collection_begin_end = collections simultan\u00E9es
+main_frame_menuitem_concurrent_collection_begin_end = collections simultan\u00e9es
 
 main_frame_menuitem_enter_fullscreen = fr Enter Full Screen
 
@@ -203,19 +203,19 @@ main_frame_menuitem_exit = Quitter
 
 main_frame_menuitem_export = Exporter
 
-main_frame_menuitem_full_gc_lines = Rep\u00E8res des GC complets
+main_frame_menuitem_full_gc_lines = Rep\u00e8res des GC complets
 
-main_frame_menuitem_gc_times_line = Courbe des dur\u00E9es des GC
+main_frame_menuitem_gc_times_line = Courbe des dur\u00e9es des GC
 
-main_frame_menuitem_gc_times_rectangles = Rectangle des dur\u00E9es des GC
+main_frame_menuitem_gc_times_rectangles = Rectangle des dur\u00e9es des GC
 
-main_frame_menuitem_hint_about = Affiche des informations g\u00E9n\u00E9rales sur GCViewer
+main_frame_menuitem_hint_about = Affiche des informations g\u00e9n\u00e9rales sur GCViewer
 
-main_frame_menuitem_hint_add_file = Ajoute une vue \u00E0 la fen\u00EAtre courante
+main_frame_menuitem_hint_add_file = Ajoute une vue \u00e0 la fen\u00eatre courante
 
-main_frame_menuitem_hint_antialias = Utilise l'antialiasing lors du trac\u00E9 des courbes (Peut ralentir la vue graphique de mani\u00E8re significative)
+main_frame_menuitem_hint_antialias = Utilise l''antialiasing lors du trac\u00e9 des courbes (Peut ralentir la vue graphique de mani\u00e8re significative)
 
-main_frame_menuitem_hint_arrange = R\u00E9organise toutes les fen\u00EAtres
+main_frame_menuitem_hint_arrange = R\u00e9organise toutes les fen\u00eatres
 
 main_frame_menuitem_hint_concurrent_collection_begin_end = f Shows lines for every begin (cyan) and end (pink) of a concurrent collection cycle.
 
@@ -225,13 +225,13 @@ main_frame_menuitem_hint_exit = Quitte GCViewer
 
 main_frame_menuitem_hint_export = Exporte le fichier courant
 
-main_frame_menuitem_hint_full_gc_lines = Affiche les r\u00E9p\u00E8res repr\u00E9sentant chaque passage des GC complets
+main_frame_menuitem_hint_full_gc_lines = Affiche les r\u00e9p\u00e8res repr\u00e9sentant chaque passage des GC complets
 
-main_frame_menuitem_hint_gc_times_line = Affiche une courbe pr\u00E9sentant l'\u00E9volution de la dur\u00E9e des passages du ramasse-miettes (GC)
+main_frame_menuitem_hint_gc_times_line = Affiche une courbe pr\u00e9sentant l''\u00e9volution de la dur\u00e9e des passages du ramasse-miettes (GC)
 
 main_frame_menuitem_hint_gc_times_rectangles = Dessine des rectangles permettant de visualiser le temps pris par le ramasse-miettes (GC)
 
-main_frame_menuitem_hint_inc_gc_lines = Affiche les r\u00E9p\u00E8res repr\u00E9sentant chaque passage des GC incr\u00E9mentaux
+main_frame_menuitem_hint_inc_gc_lines = Affiche les r\u00e9p\u00e8res repr\u00e9sentant chaque passage des GC incr\u00e9mentaux
 
 main_frame_menuitem_hint_initial_mark_level = f Shows level of memory at initial-mark (only available for algorithms with concurrent collections).
 
@@ -245,29 +245,29 @@ main_frame_menuitem_hint_open_url = Ouvre une URL
 
 main_frame_menuitem_hint_readme = (f) read various information about GCViewer
 
-main_frame_menuitem_hint_recent_files = Pr\u00E9senter un fichier r\u00E9cemment ouvert
+main_frame_menuitem_hint_recent_files = Pr\u00e9senter un fichier r\u00e9cemment ouvert
 
 main_frame_menuitem_hint_refresh = Recharge le fichier courant
 
-main_frame_menuitem_hint_show_data_panel = Affiche les onglets des statistiques d\u00E9taill\u00E9es concernant la vue courante
+main_frame_menuitem_hint_show_data_panel = Affiche les onglets des statistiques d\u00e9taill\u00e9es concernant la vue courante
 
-main_frame_menuitem_hint_show_datestamps = Affiche les onglets des statistiques d\u00E9taill\u00E9es concernant la vue courante
+main_frame_menuitem_hint_show_datestamps = Affiche les onglets des statistiques d\u00e9taill\u00e9es concernant la vue courante
 
-main_frame_menuitem_hint_tenured_memory = Part de la m\u00E9moire allou\u00E9e r\u00E9serv\u00E9e pour les anciennes g\u00E9n\u00E9rations
+main_frame_menuitem_hint_tenured_memory = Part de la m\u00e9moire allou\u00e9e r\u00e9serv\u00e9e pour les anciennes g\u00e9n\u00e9rations
 
-main_frame_menuitem_hint_total_memory = Quantit\u00E9 de m\u00E9moire allou\u00E9e
+main_frame_menuitem_hint_total_memory = Quantit\u00e9 de m\u00e9moire allou\u00e9e
 
-main_frame_menuitem_hint_used_memory = Quantit\u00E9 de m\u00E9moire effectivement utilis\u00E9e
+main_frame_menuitem_hint_used_memory = Quantit\u00e9 de m\u00e9moire effectivement utilis\u00e9e
 
-main_frame_menuitem_hint_used_tenured_memory = Quantit\u00E9 de m\u00E9moire effectivement utilis\u00E9e (g\u00E9n\u00E9rations anciennes)
+main_frame_menuitem_hint_used_tenured_memory = Quantit\u00e9 de m\u00e9moire effectivement utilis\u00e9e (g\u00e9n\u00e9rations anciennes)
 
-main_frame_menuitem_hint_used_young_memory = Quantit\u00E9 de m\u00E9moire effectivement utilis\u00E9e (g\u00E9n\u00E9rations nouvelles)
+main_frame_menuitem_hint_used_young_memory = Quantit\u00e9 de m\u00e9moire effectivement utilis\u00e9e (g\u00e9n\u00e9rations nouvelles)
 
 main_frame_menuitem_hint_watch = Surveille et recharge le fichier courant si ce dernier subit des modifications
 
-main_frame_menuitem_hint_young_memory = Par de la m\u00E9moire allou\u00E9e r\u00E9serv\u00E9e pour la nouvelle g\u00E9n\u00E9ration
+main_frame_menuitem_hint_young_memory = Par de la m\u00e9moire allou\u00e9e r\u00e9serv\u00e9e pour la nouvelle g\u00e9n\u00e9ration
 
-main_frame_menuitem_inc_gc_lines = Rep\u00E8res des GC incr\u00E9mentaux
+main_frame_menuitem_inc_gc_lines = Rep\u00e8res des GC incr\u00e9mentaux
 
 main_frame_menuitem_initial_mark_level = f initial mark level
 
@@ -335,32 +335,32 @@ main_frame_menuitem_open_url = Ouvrir une URL
 
 main_frame_menuitem_readme = Readme
 
-main_frame_menuitem_recent_files = Fichiers r\u00E9cents
+main_frame_menuitem_recent_files = Fichiers r\u00e9cents
 
-main_frame_menuitem_refresh = Rafra\u00EEchir
+main_frame_menuitem_refresh = Rafra\u00eechir
 
 main_frame_menuitem_show_data_panel = Statistiques
 
 main_frame_menuitem_show_datestamps = (fr)show datestamps
 
-main_frame_menuitem_tenured_memory = Anciennes g\u00E9n\u00E9rations
+main_frame_menuitem_tenured_memory = Anciennes g\u00e9n\u00e9rations
 
-main_frame_menuitem_total_memory = M\u00E9moire allou\u00E9e
+main_frame_menuitem_total_memory = M\u00e9moire allou\u00e9e
 
-main_frame_menuitem_used_memory = M\u00E9moire utilis\u00E9e
+main_frame_menuitem_used_memory = M\u00e9moire utilis\u00e9e
 
-main_frame_menuitem_used_tenured_memory = M\u00E9moire ancienne utilis\u00E9e
+main_frame_menuitem_used_tenured_memory = M\u00e9moire ancienne utilis\u00e9e
 
-main_frame_menuitem_used_young_memory = M\u00E9moire nouvelle utilis\u00E9e
+main_frame_menuitem_used_young_memory = M\u00e9moire nouvelle utilis\u00e9e
 
 main_frame_menuitem_watch = Surveiller
 
-main_frame_menuitem_young_memory = Nouvelle g\u00E9n\u00E9ration
+main_frame_menuitem_young_memory = Nouvelle g\u00e9n\u00e9ration
 
-timeoffset_prompt = Date d\u00E9marrage du journal :
+timeoffset_prompt = Date d\u00e9marrage du journal :
 
-urlopen_dialog_add_checkbox = Ajouter l'URL \u00E0 la fen\u00EAtre courante.
+urlopen_dialog_add_checkbox = Ajouter l''URL \u00e0 la fen\u00eatre courante.
 
-urlopen_dialog_hint_add_checkbox = <html>Si coch\u00E9, le nouveau journal sera ajout\u00E9<br>\u00E0 la fen\u00EAtre courante, au lieu d'\u00EAtre ouvert dans une nouvelle fen\u00EAtre.</html>
+urlopen_dialog_hint_add_checkbox = <html>Si coch\u00e9, le nouveau journal sera ajout\u00e9<br>\u00e0 la fen\u00eatre courante, au lieu d''\u00eatre ouvert dans une nouvelle fen\u00eatre.</html>
 
-urlopen_dialog_title = Ouvrir l'URL d'un journal
+urlopen_dialog_title = Ouvrir l''URL d''un journal


### PR DESCRIPTION
The quotes of the localized messages were not displayed and unit test "LocalisationHelperTest" crashed because the argument were not replaced.
- DataReaderFacade.java: use the LocalisationHelper.getString with arguments
instead of performing the format ourself.
- localStrings_fr.properties: replace each single quote with two single 
quotes as stated in the javadoc of MessageFormat class:
https://docs.oracle.com/javase/8/docs/api/java/text/MessageFormat.html#patterns
Otherwise the single quote won't appear in the message and the arguments are not parsed.