### PR TITLE
Add support for "Min / max full GC pause interval".

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,8 @@ Pause
   - Average length of a full GC pause
 - Min / max full GC pause:
   - Shortest / longest full GC pause
+- Min / max full GC pause interval:
+  - Min / max interval between two pauses due to full collections
   
 * * *
 - Acc GC:

--- a/src/main/java/com/tagtraum/perf/gcviewer/ModelPanel.java
+++ b/src/main/java/com/tagtraum/perf/gcviewer/ModelPanel.java
@@ -378,6 +378,7 @@ public class ModelPanel extends JTabbedPane {
             addEntry(LocalisationHelper.getString("data_panel_count_full_gc_pauses"));
             addEntry(LocalisationHelper.getString("data_panel_avg_fullgcpause"));
             addEntry(LocalisationHelper.getString("data_panel_min_max_full_gc_pause"));
+            addEntry(LocalisationHelper.getString("data_panel_min_max_full_gc_pause_interval"));
 
             newGroup(LocalisationHelper.getString("data_panel_group_gc_pauses"), true);
             addEntry(LocalisationHelper.getString("data_panel_acc_gcpauses"));
@@ -390,6 +391,7 @@ public class ModelPanel extends JTabbedPane {
             boolean pauseDataAvailable = model.getPause().getN() > 0;
             boolean gcDataAvailable = model.getGCPause().getN() > 0;
             boolean fullGCDataAvailable = model.getFullGCPause().getN() > 0;
+            boolean fullGcPauseIntervalAvailable = model.getFullGCPauseInterval().getN() > 0;
             boolean pauseIntervalDataAvailable = model.getPauseInterval().getN() > 0; // fix for "Exception if only one GC log line in file"
             boolean vmOperationsAvailable = model.getVmOperationPause().getN() > 0;
             
@@ -437,6 +439,9 @@ public class ModelPanel extends JTabbedPane {
             updateValue(LocalisationHelper.getString("data_panel_min_max_full_gc_pause"), 
             		fullGCDataAvailable ? pauseFormatter.format(model.getFullGCPause().getMin()) + "s / " + pauseFormatter.format(model.getFullGCPause().getMax()) + "s" : "n/a", 
             		fullGCDataAvailable);
+            updateValue(LocalisationHelper.getString("data_panel_min_max_full_gc_pause_interval"),
+                    fullGcPauseIntervalAvailable ? pauseFormatter.format(model.getFullGCPauseInterval().getMin()) + "s / " + pauseFormatter.format(model.getFullGCPauseInterval().getMax()) + "s" : "n/a",
+                    fullGcPauseIntervalAvailable);
 
             updateValue(LocalisationHelper.getString("data_panel_acc_gcpauses"), 
             		gcTimeFormatter.format(model.getGCPause().getSum())+ "s (" + percentFormatter.format(model.getGCPause().getSum()*100.0/model.getPause().getSum()) + "%)", 

--- a/src/main/resources/com/tagtraum/perf/gcviewer/localStrings.properties
+++ b/src/main/resources/com/tagtraum/perf/gcviewer/localStrings.properties
@@ -103,6 +103,8 @@ data_panel_memory_young_heap_usage = Young heap (usage / alloc. max)
 
 data_panel_min_max_full_gc_pause = Min / max full gc pause
 
+data_panel_min_max_full_gc_pause_interval = Min / max full gc pause interval
+
 data_panel_min_max_gc_pause = Min / max gc pause
 
 data_panel_min_max_pause = Min / Max Pause


### PR DESCRIPTION
Adding support for "Min / max full GC pause interval".
It appears in the "Data Panel",in the "Pause" tab,in the
"Full gc pauses" frame.

The value will be the maximum and minimum time between full GCs.

See issue #14 .

Signed-off-by: Fred Rolland <rollandf@gmail.com>