### PR TITLE
Feature/#61: Improve logfile parsing speed by factor 2 for AbstractDataReaderSun

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -172,7 +172,7 @@
         <maven.antrun.plugin.version>1.8</maven.antrun.plugin.version>
         <maven.compiler.plugin.version>3.3</maven.compiler.plugin.version>
         <maven.buildnumber.plugin.version>1.3</maven.buildnumber.plugin.version>
-        <maven.jar.plugin.version>2.6</maven.jar.plugin.version>
+        <maven.shade.plugin.version>2.4.3</maven.shade.plugin.version>
         <maven.surefire.plugin.version>2.18.1</maven.surefire.plugin.version>
         <maven.release.plugin.version>2.5.2</maven.release.plugin.version>
         <maven.scm.plugin.version>1.9.4</maven.scm.plugin.version>
@@ -187,6 +187,12 @@
     </scm>
 
     <dependencies>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.4</version>
+            <scope>compile</scope>
+        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
@@ -269,46 +275,6 @@
                         <timestampPropertyName>timestamp</timestampPropertyName>
                         <timestampFormat>{0,date,yyyy-MM-dd'T'HH:mm:ssZZ}</timestampFormat>
                         <getRevisionOnlyOnce>true</getRevisionOnlyOnce>
-                    </configuration>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-jar-plugin</artifactId>
-                    <version>${maven.jar.plugin.version}</version>
-                    <configuration>
-                        <archive>
-                            <manifest>
-                                <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
-                                <mainClass>com.tagtraum.perf.gcviewer.GCViewer</mainClass>
-                                <addClasspath>true</addClasspath>
-                            </manifest>
-                            <manifestEntries>
-                                <Implementation-Date>${timestamp}</Implementation-Date>
-                                <Implementation-Revision>${revision}</Implementation-Revision>
-                            </manifestEntries>
-                        </archive>
-                        <excludes>
-                            <exclude>**/*.psd</exclude>
-                        </excludes>
-                    </configuration>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>${maven.javadoc.plugin.version}</version>
-                    <configuration>
-                        <archive>
-                            <manifest>
-                                <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
-                            </manifest>
-                            <manifestEntries>
-                                <Implementation-Date>${timestamp}</Implementation-Date>
-                                <Implementation-Revision>${revision}</Implementation-Revision>
-                            </manifestEntries>
-                        </archive>
-                        <links>
-                            <link>http://docs.oracle.com/javase/8/docs/api/</link>
-                        </links>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -532,6 +498,31 @@
                                     </limits>
                                 </rule>
                             </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>${maven.shade.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <minimizeJar>true</minimizeJar>
+                            <createDependencyReducedPom>true</createDependencyReducedPom>
+                            <dependencyReducedPomLocation>
+                                ${java.io.tmpdir}/dependency-reduced-pom.xml
+                            </dependencyReducedPomLocation>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>com.tagtraum.perf.gcviewer.GCViewer</mainClass>
+                                </transformer>
+                            </transformers>
                         </configuration>
                     </execution>
                 </executions>

--- a/src/test/java/com/tagtraum/perf/gcviewer/imp/TestAbstractDataReaderSun.java
+++ b/src/test/java/com/tagtraum/perf/gcviewer/imp/TestAbstractDataReaderSun.java
@@ -9,8 +9,12 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 
+import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 
 public class TestAbstractDataReaderSun {
 
@@ -90,7 +94,16 @@ public class TestAbstractDataReaderSun {
         assertEquals("heap before", 121344, event.getPreUsed());
         assertEquals("heap after", 128, event.getPostUsed());
     }
-    
+
+    @Test
+    public void testParseDatestamp() throws Exception {
+        String line =
+                "2016-04-14T22:37:55.315+0200: 467.260: [GC (Allocation Failure) 467.260: [ParNew: 226563K->6586K(245760K), 0.0044323 secs] 385679K->165875K(791936K), 0.0045438 secs] [Times: user=0.00 sys=0.00, real=0.00 secs] ";
+        ParseInformation pos = new ParseInformation(0);
+        ZonedDateTime time = dataReader.parseDatestamp(line, pos);
+        assertThat(time, is(ZonedDateTime.of(2016, 4, 14, 22, 37, 55, 315000000, ZoneOffset.ofHours(2))));
+    }
+
     /**
      * Subclass of {@link AbstractDataReaderSun} which makes those methods public, I want to test here.
      * 

--- a/src/test/java/com/tagtraum/perf/gcviewer/imp/TestDataReaderSun1_6_0.java
+++ b/src/test/java/com/tagtraum/perf/gcviewer/imp/TestDataReaderSun1_6_0.java
@@ -1,17 +1,17 @@
 package com.tagtraum.perf.gcviewer.imp;
 
 import com.tagtraum.perf.gcviewer.UnittestHelper;
-import com.tagtraum.perf.gcviewer.model.GcResourceFile;
 import com.tagtraum.perf.gcviewer.model.GCEvent;
 import com.tagtraum.perf.gcviewer.model.GCModel;
 import com.tagtraum.perf.gcviewer.model.GCResource;
+import com.tagtraum.perf.gcviewer.model.GcResourceFile;
 import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.logging.Level;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -20,7 +20,6 @@ import static org.junit.Assert.*;
 
 public class TestDataReaderSun1_6_0 {
 
-    private final DateTimeFormatter dateTimeFormatter = AbstractDataReaderSun.DATE_TIME_FORMATTER;
 
     private InputStream getInputStream(String fileName) throws IOException {
         return UnittestHelper.getResourceAsStream(UnittestHelper.FOLDER_OPENJDK, fileName);
@@ -28,19 +27,18 @@ public class TestDataReaderSun1_6_0 {
 
     @Test
     public void testPrintGCDateStamps() throws Exception {
-		ByteArrayInputStream in = new ByteArrayInputStream(
-				("2011-10-05T04:23:39.427+0200: 19.845: [GC 19.845: [ParNew: 93184K->5483K(104832K), 0.0384413 secs] 93184K->5483K(1036928K), 0.0388082 secs] [Times: user=0.41 sys=0.06, real=0.04 secs]")
-						.getBytes());
-		 
-        DataReader reader = new DataReaderSun1_6_0(new GcResourceFile("byteArray"), in, GcLogType.SUN1_6);
-		GCModel model = reader.read();
+        ByteArrayInputStream in =
+                new ByteArrayInputStream(("2011-10-05T04:23:39.427+0200: 19.845: [GC 19.845: [ParNew: 93184K->5483K(104832K), 0.0384413 secs] 93184K->5483K(1036928K), 0.0388082 secs] [Times: user=0.41 sys=0.06, real=0.04 secs]").getBytes());
 
-		assertTrue("hasDateStamp", model.hasDateStamp());
-		assertEquals("DateStamp",
-				ZonedDateTime.parse("2011-10-05T04:23:39.427+0200", dateTimeFormatter),
-				model.getFirstDateStamp());
+        DataReader reader = new DataReaderSun1_6_0(new GcResourceFile("byteArray"), in, GcLogType.SUN1_6);
+        GCModel model = reader.read();
+
+        assertTrue("hasDateStamp", model.hasDateStamp());
+        ZonedDateTime expected =
+                ZonedDateTime.from(AbstractDataReaderSun.DATE_TIME_FORMATTER.parse("2011-10-05T04:23:39.427+0200").toInstant().atZone(ZoneOffset.ofHours(2)));
+        assertEquals("DateStamp", expected, model.getFirstDateStamp());
         assertEquals("gc pause", 0.0388082, model.getGCPause().getMax(), 0.000001);
-	}
+    }
 
     @Test
 	public void testCMSPromotionFailed() throws Exception {

--- a/src/test/java/com/tagtraum/perf/gcviewer/imp/TestDataReaderSun1_6_0G1.java
+++ b/src/test/java/com/tagtraum/perf/gcviewer/imp/TestDataReaderSun1_6_0G1.java
@@ -2,16 +2,16 @@ package com.tagtraum.perf.gcviewer.imp;
 
 import com.tagtraum.perf.gcviewer.UnittestHelper;
 import com.tagtraum.perf.gcviewer.model.AbstractGCEvent.Type;
-import com.tagtraum.perf.gcviewer.model.GcResourceFile;
 import com.tagtraum.perf.gcviewer.model.GCModel;
 import com.tagtraum.perf.gcviewer.model.GCResource;
+import com.tagtraum.perf.gcviewer.model.GcResourceFile;
 import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.logging.Level;
 
 import static org.hamcrest.Matchers.*;
@@ -20,8 +20,6 @@ import static org.junit.Assert.assertThat;
 
 public class TestDataReaderSun1_6_0G1 {
     
-    private final DateTimeFormatter dateTimeFormatter = AbstractDataReaderSun.DATE_TIME_FORMATTER;
-
     private InputStream getInputStream(String fileName) throws IOException {
         return UnittestHelper.getResourceAsStream(UnittestHelper.FOLDER_OPENJDK, fileName);
     }
@@ -31,11 +29,11 @@ public class TestDataReaderSun1_6_0G1 {
      */
     @Test
     public void testG1GcVerbose() throws Exception {
-    	TestLogHandler handler = new TestLogHandler();
+        TestLogHandler handler = new TestLogHandler();
         handler.setLevel(Level.WARNING);
         GCResource gcResource = new GcResourceFile("SampleSun1_6_0G1_gc_verbose.txt");
         gcResource.getLogger().addHandler(handler);
-    	
+
         InputStream in = getInputStream(gcResource.getResourceName());
         DataReader reader = new DataReaderSun1_6_0G1(gcResource, in, GcLogType.SUN1_6G1);
         GCModel model = reader.read();
@@ -71,30 +69,25 @@ public class TestDataReaderSun1_6_0G1 {
 
         assertEquals("count", 1, model.size());
         assertEquals("gc pause", 0.0032067, model.getGCPause().getMax(), 0.000001);
-        assertEquals("datestamp", 
-                ZonedDateTime.parse("2012-02-29T13:41:00.721+0100", dateTimeFormatter),
-                model.getGCEvents().next().getDatestamp());
+        ZonedDateTime expected = ZonedDateTime.from(AbstractDataReaderSun.DATE_TIME_FORMATTER.parse("2012-02-29T13:41:00.721+0100").toInstant().atZone(ZoneOffset.ofHours(1)));
+        assertEquals("datestamp", expected, model.getGCEvents().next().getDatestamp());
     }
-    
+
     @Test
     public void testG1FullGcSystemGc() throws Exception {
-    	InputStream in = new ByteArrayInputStream(
-				("9.978: [Full GC (System.gc()) 597M->1142K(7168K), 0.1604955 secs]")
-				.getBytes());
-    	
-		DataReader reader = new DataReaderSun1_6_0G1(new GcResourceFile("byteArray"), in, GcLogType.SUN1_6G1);
-		GCModel model = reader.read();
+        InputStream in = new ByteArrayInputStream(("9.978: [Full GC (System.gc()) 597M->1142K(7168K), 0.1604955 secs]").getBytes());
 
-		assertEquals("count", 1, model.size());
-		assertEquals("full gc pause", 0.1604955, model.getFullGCPause().getMax(), 0.000001);
+        DataReader reader = new DataReaderSun1_6_0G1(new GcResourceFile("byteArray"), in, GcLogType.SUN1_6G1);
+        GCModel model = reader.read();
 
+        assertEquals("count", 1, model.size());
+        assertEquals("full gc pause", 0.1604955, model.getFullGCPause().getMax(), 0.000001);
     }
     
     @Test
     public void testG1MixedLine1() throws Exception {
         InputStream in = new ByteArrayInputStream(
-                ("0.388: [GC pause (young) (initial-mark) 10080K->10080K(16M)0.390: [GC concurrent-mark-start]" +
-                		"\n, 0.0013065 secs]")
+                ("0.388: [GC pause (young) (initial-mark) 10080K->10080K(16M)0.390: [GC concurrent-mark-start]" + "\n, 0.0013065 secs]")
                 .getBytes());
         
         DataReader reader = new DataReaderSun1_6_0G1(new GcResourceFile("byteArray"), in, GcLogType.SUN1_6G1);
@@ -183,8 +176,8 @@ public class TestDataReaderSun1_6_0G1 {
     @Test
     public void testFullGcMixed() throws Exception {
         InputStream in = new ByteArrayInputStream(("107.222: [Full GC107.248: [GC concurrent-mark-end, 0.0437048 sec]" +
-        		"\n 254M->59M(199M), 0.0687356 secs]" +
-        		"\n [Times: user=0.06 sys=0.02, real=0.07 secs]").getBytes());
+                "\n 254M->59M(199M), 0.0687356 secs]" +
+                "\n [Times: user=0.06 sys=0.02, real=0.07 secs]").getBytes());
         DataReader reader = new DataReaderSun1_6_0G1(new GcResourceFile("byteArray"), in, GcLogType.SUN1_6G1);
         GCModel model = reader.read();
 

--- a/src/test/java/com/tagtraum/perf/gcviewer/imp/TestDataReaderSun1_7_0.java
+++ b/src/test/java/com/tagtraum/perf/gcviewer/imp/TestDataReaderSun1_7_0.java
@@ -1,10 +1,8 @@
 package com.tagtraum.perf.gcviewer.imp;
 
-import static org.hamcrest.Matchers.closeTo;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import com.tagtraum.perf.gcviewer.UnittestHelper;
+import com.tagtraum.perf.gcviewer.model.*;
+import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -13,9 +11,9 @@ import java.time.format.DateTimeFormatter;
 import java.util.Iterator;
 import java.util.logging.Level;
 
-import com.tagtraum.perf.gcviewer.model.*;
-import org.junit.Test;
-import com.tagtraum.perf.gcviewer.UnittestHelper;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 
 /**
  * Tests for logs generated specifically by jdk 1.7.0.
@@ -24,8 +22,6 @@ import com.tagtraum.perf.gcviewer.UnittestHelper;
  * <p>created on: 13.09.2013</p>
  */
 public class TestDataReaderSun1_7_0 {
-
-    private final DateTimeFormatter dateTimeFormatter = AbstractDataReaderSun.DATE_TIME_FORMATTER;
 
     private InputStream getInputStream(String fileName) throws IOException {
         return UnittestHelper.getResourceAsStream(UnittestHelper.FOLDER_OPENJDK, fileName);
@@ -386,7 +382,7 @@ public class TestDataReaderSun1_7_0 {
                 model.get(1).getTimestamp(),
                 closeTo(33395.153 + 0.1120380, 0.0000001));
         assertThat("Application Stopped datestamp",
-                dateTimeFormatter.format(model.get(1).getDatestamp()),
+                model.get(1).getDatestamp().format(DateTimeFormatter.ofPattern(AbstractDataReaderSun.TIMESTAMP_PATTERN)),
                 equalTo("2012-04-26T23:59:51.011+0400"));
         assertThat("first timestamp", model.getFirstPauseTimeStamp(), closeTo(33395.153, 0.00001));
     }


### PR DESCRIPTION
This is a follow up for PR #176 that improves the parsing speed for parsers based on AbstractDataReaderSun.

Profiling showed that a large part of the time for parsing a logfile is spent
while parsing the contained datestamps. This is noticeable when either big logfiles or a series of logfiles are parsed.
See https://github.com/geld0r/DateTimeFormatBenchmarks for a speed comparison of various DateTimeFormatters.
FastDateFormat was chosen as a replacement and Apache Commons Lang added as dependency.
Hand timed benchmarks show that parsing logfiles of supported types now works roughly twice as fast.

Note that this required to add Apache commons-lang3 as project dependencies. It contains many utilities that are useful and avoids having to rewrite them. Among them is FastDateFormat, which is a thread-safe and fast alternative to SimpleDateFormat. This is now used for parsing dates in such logfiles.