### PR TITLE
Complete french translation

### DIFF
--- a/src/main/resources/localStrings_fr.properties
+++ b/src/main/resources/localStrings_fr.properties
@@ -242,9 +242,10 @@ main_frame_menuitem_hint_license = information sur la licence
 main_frame_menuitem_hint_open_file = Ouvre un fichier
 
 main_frame_menuitem_hint_open_series=Ouvre plusieurs fichiers comme un seul fichier
+
 main_frame_menuitem_hint_open_url = Ouvre une URL
 
-main_frame_menuitem_hint_readme = diverses informations à proos de GCViewer
+main_frame_menuitem_hint_readme = Diverses informations \u00E0 propos de GCViewer
 
 main_frame_menuitem_hint_recent_files = Pr\u00E9senter un fichier r\u00E9cemment ouvert
 

--- a/src/main/resources/localStrings_fr.properties
+++ b/src/main/resources/localStrings_fr.properties
@@ -19,7 +19,7 @@ data_panel_acc_fullgcpauses = GC complet tot
 
 data_panel_acc_gcpauses = GC tot
 
-data_panel_acc_pauses = Pauses tot
+data_panel_acc_pauses = Pauses totales
 
 data_panel_avg_fullgcpause = GC complet moy
 
@@ -27,7 +27,7 @@ data_panel_avg_gcpause = GC moy
 
 data_panel_avg_pause = Pause moy
 
-data_panel_avg_pause_interval = fr Avg pause interval
+data_panel_avg_pause_interval = moy interval de pause
 
 data_panel_avgfreedmemorybyfullgc = M\u00E9m lib moy GC complet
 
@@ -37,11 +37,11 @@ data_panel_avgrelativepostfullgcincrease = Accr rel moy apr\u00E8s GC complet
 
 data_panel_avgrelativepostgcincrease = Accr rel moy apr\u00E8s GC
 
-data_panel_count_full_gc_pauses = f Number of full gc pauses
+data_panel_count_full_gc_pauses = Nombre de pauses full gc
 
-data_panel_count_gc_pauses = f Number of gc pauses
+data_panel_count_gc_pauses = Nombre de pauses gc
 
-data_panel_count_pauses = f Number of pauses
+data_panel_count_pauses = Nombre de pauses
 
 data_panel_details_avg = avg (s)
 
@@ -53,13 +53,13 @@ data_panel_details_min = min (s)
 
 data_panel_details_name = nom
 
-data_panel_details_stddev = f stddev
+data_panel_details_stddev = \u00E9cart type
 
-data_panel_details_sum = f sum (s)
+data_panel_details_sum = somme (s)
 
-data_panel_details_sum_percent = f sum (%)
+data_panel_details_sum_percent = somme (%)
 
-data_panel_details_total = f total
+data_panel_details_total = total
 
 data_panel_footprintafterconcgc_avg = Moy apr\u00E8s GC simultan\u00E9e
 
@@ -81,33 +81,33 @@ data_panel_freedmemorypermin = M\u00E9m lib/Min
 
 data_panel_group_concurrent_gc_events = GCs simultan\u00E9es
 
-data_panel_group_full_gc_pauses = f Full gc pauses
+data_panel_group_full_gc_pauses = Pauses full gc
 
-data_panel_group_gc_pauses = f Gc pauses
+data_panel_group_gc_pauses = Pauses gc
 
-data_panel_group_total_pause = f Total pause
+data_panel_group_total_pause = Total des pauses
 
-data_panel_memory_heap_usage = fr Total heap (usage / alloc. max)
+data_panel_memory_heap_usage = Total heap (usage / alloc. max)
 
 data_panel_memory_initiatingoccupancyfraction = InitiatingOccFraction (avg / max)
 
-data_panel_memory_perm_heap_usage = fr Perm heap (usage / alloc. max)
+data_panel_memory_perm_heap_usage = Perm heap (usage / alloc. max)
 
-data_panel_memory_promotion_avg = f avg promotion
+data_panel_memory_promotion_avg = Promotion moyenne
 
-data_panel_memory_promotion_total = f total promotion
+data_panel_memory_promotion_total = Promotion totale
 
-data_panel_memory_tenured_heap_usage = fr Tenured heap (usage / alloc. max)
+data_panel_memory_tenured_heap_usage = Tenured heap (usage / alloc. max)
 
-data_panel_memory_young_heap_usage = fr Young heap (usage / alloc. max)
+data_panel_memory_young_heap_usage = Young heap (usage / alloc. max)
 
-data_panel_min_max_full_gc_pause = f Min / max full gc pause
+data_panel_min_max_full_gc_pause = Min / max full gc pause
 
-data_panel_min_max_gc_pause = f Min / max gc pause
+data_panel_min_max_gc_pause = Min / max gc pause
 
 data_panel_min_max_pause = Pause min / max
 
-data_panel_min_max_pause_interval = fr Min / max pause interval
+data_panel_min_max_pause_interval = Min / max pause interval
 
 data_panel_performance_fullgc = Performance GC complet
 
@@ -117,13 +117,13 @@ data_panel_slopeafterfullgc = Pente GC complet
 
 data_panel_slopeaftergc = Pente GC
 
-data_panel_tab_chart = f Chart
+data_panel_tab_chart = Graphique
 
-data_panel_tab_details = f Event details
+data_panel_tab_details = D\u00E9tails des \u00E9v\u00E9nements 
 
 data_panel_tab_memory = M\u00E9moire
 
-data_panel_tab_parser = (fr)Parser
+data_panel_tab_parser = Parseur
 
 data_panel_tab_pause = Pause
 
@@ -135,11 +135,11 @@ data_panel_tenuredafterconcgc_max = Max ancienne apr\u00E8s GC simultan\u00E9e
 
 data_panel_throughput = Throughput
 
-data_panel_total_time = dur\u00E9e totale
+data_panel_total_time = Dur\u00E9e totale
 
-data_panel_vm_op_overhead = fr VM Operation Overhead
+data_panel_vm_op_overhead = Overhead des op\u00E9rations de la VM
 
-datareader_parseerror_dialog_message = L''analyse syntaxique effectu\u00E9e par GCViewer a rencontr\u00E9 {0} probl\u00E8mes "{1}"\:
+datareader_parseerror_dialog_message = L''analyse syntaxique effectu\u00E9e par GCViewer a rencontr\u00E9 {0} probl\u00E8me(s) \:
 
 datareaderfactory_instantiation_failed = La reconnaissance du format du journal a \u00E9chou\u00E9.
 
@@ -153,9 +153,9 @@ fileexport_dialog_csv_ts = Donn\u00E9es s\u00E9par\u00E9es par des virgules avec
 
 fileexport_dialog_error_occured = Une erreur est survenue.
 
-fileexport_dialog_simplelog = f Simple GC Log (GCHisto compatible, *.simple.log)
+fileexport_dialog_simplelog = Simple GC Log (compatible avec GCHisto, *.simple.log)
 
-fileexport_dialog_summarylog = f Summary GC Log (*.csv)
+fileexport_dialog_summarylog = R\u00E9sum\u00E9 du log (*.csv)
 
 fileexport_dialog_title = Exporter le journal
 
@@ -197,7 +197,7 @@ main_frame_menuitem_arrange = R\u00E9organiser
 
 main_frame_menuitem_concurrent_collection_begin_end = collections simultan\u00E9es
 
-main_frame_menuitem_enter_fullscreen = fr Enter Full Screen
+main_frame_menuitem_enter_fullscreen = Passer en plein \u00E9cran
 
 main_frame_menuitem_exit = Quitter
 
@@ -217,9 +217,9 @@ main_frame_menuitem_hint_antialias = Utilise l''antialiasing lors du trac\u00E9 
 
 main_frame_menuitem_hint_arrange = R\u00E9organise toutes les fen\u00EAtres
 
-main_frame_menuitem_hint_concurrent_collection_begin_end = f Shows lines for every begin (cyan) and end (pink) of a concurrent collection cycle.
+main_frame_menuitem_hint_concurrent_collection_begin_end = Affiche les lignes pour chaque d\u00E9but (cyan) et fin (pink) d''un cycle de collection concurrente.
 
-main_frame_menuitem_hint_enter_fullscreen = fr Switch to full screen mode
+main_frame_menuitem_hint_enter_fullscreen = Passer en mode plein \u00E9cran
 
 main_frame_menuitem_hint_exit = Quitte GCViewer
 
@@ -233,17 +233,18 @@ main_frame_menuitem_hint_gc_times_rectangles = Dessine des rectangles permettant
 
 main_frame_menuitem_hint_inc_gc_lines = Affiche les r\u00E9p\u00E8res repr\u00E9sentant chaque passage des GC incr\u00E9mentaux
 
-main_frame_menuitem_hint_initial_mark_level = f Shows level of memory at initial-mark (only available for algorithms with concurrent collections).
+main_frame_menuitem_hint_initial_mark_level = Affiche la quantit\u00E9 de \u00E9moire de la phase initial-mark (seulement pour les algorithmes de collections concurrentes).
 
-main_frame_menuitem_hint_leave_fullscreen = fr Exit full screen mode
+main_frame_menuitem_hint_leave_fullscreen = Quitter le mode plein \u00E9cran
 
-main_frame_menuitem_hint_license = (f) license information
+main_frame_menuitem_hint_license = information sur la licence
 
 main_frame_menuitem_hint_open_file = Ouvre un fichier
 
+main_frame_menuitem_hint_open_series=Ouvre plusieurs fichiers comme un seul fichier
 main_frame_menuitem_hint_open_url = Ouvre une URL
 
-main_frame_menuitem_hint_readme = (f) read various information about GCViewer
+main_frame_menuitem_hint_readme = diverses informations à proos de GCViewer
 
 main_frame_menuitem_hint_recent_files = Pr\u00E9senter un fichier r\u00E9cemment ouvert
 
@@ -251,7 +252,7 @@ main_frame_menuitem_hint_refresh = Recharge le fichier courant
 
 main_frame_menuitem_hint_show_data_panel = Affiche les onglets des statistiques d\u00E9taill\u00E9es concernant la vue courante
 
-main_frame_menuitem_hint_show_date_stamp = (fr)Changes between display of time since beginning in seconds and absolute datestamps.
+main_frame_menuitem_hint_show_date_stamp = Affiche les dates absolues ou alors le temps \u00E9coul\u00E9 depuis le d\u00E9marrage de la JVM.
 
 main_frame_menuitem_hint_tenured_memory = Part de la m\u00E9moire allou\u00E9e r\u00E9serv\u00E9e pour les anciennes g\u00E9n\u00E9rations
 
@@ -269,11 +270,11 @@ main_frame_menuitem_hint_young_memory = Par de la m\u00E9moire allou\u00E9e r\u0
 
 main_frame_menuitem_inc_gc_lines = Rep\u00E8res des GC incr\u00E9mentaux
 
-main_frame_menuitem_initial_mark_level = f initial mark level
+main_frame_menuitem_initial_mark_level = mark level initial
 
-main_frame_menuitem_leave_fullscreen = fr Exit Full Screen
+main_frame_menuitem_leave_fullscreen = Quitter le mode plein \u00E9cran
 
-main_frame_menuitem_license = (f) License
+main_frame_menuitem_license = License
 
 main_frame_menuitem_mnemonic_about = A
 
@@ -342,7 +343,7 @@ main_frame_menuitem_refresh = Rafra\u00EEchir
 
 main_frame_menuitem_show_data_panel = Statistiques
 
-main_frame_menuitem_show_date_stamp = (fr)show datestamps
+main_frame_menuitem_show_date_stamp = afficher les dates
 
 main_frame_menuitem_tenured_memory = Anciennes g\u00E9n\u00E9rations
 


### PR DESCRIPTION
Complete french translation in order to fix leading strings of characters like '(fr)', 'fr' or 'f' in not translated texts.

I didn't translate words like 'full gc', because it makes it strange to translate it.