### PR TITLE
Implement Red Hat's Shenandoah GC parsing

### DIFF
--- a/src/main/java/com/tagtraum/perf/gcviewer/imp/DataReaderFactory.java
+++ b/src/main/java/com/tagtraum/perf/gcviewer/imp/DataReaderFactory.java
@@ -1,5 +1,8 @@
 package com.tagtraum.perf.gcviewer.imp;
 
+import com.tagtraum.perf.gcviewer.model.GCResource;
+import com.tagtraum.perf.gcviewer.util.LocalisationHelper;
+
 import java.io.BufferedInputStream;
 import java.io.EOFException;
 import java.io.IOException;
@@ -8,9 +11,6 @@ import java.util.StringTokenizer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.zip.GZIPInputStream;
-
-import com.tagtraum.perf.gcviewer.model.GCResource;
-import com.tagtraum.perf.gcviewer.util.LocalisationHelper;
 
 /**
  *
@@ -201,6 +201,11 @@ public class DataReaderFactory {
         else if (s.indexOf("starting collection, threshold allocation reached.") != -1) {
             if (getLogger().isLoggable(Level.INFO)) getLogger().info("File format: IBM i5/OS 1.4.2");
             return new DataReaderIBMi5OS1_4_2(gcResource, in);
+        }
+        // Shenandoah
+        else if (s.contains("Using Shenandoah")) {
+            if (getLogger().isLoggable(Level.INFO)) getLogger().info("File format: Red Hat Shenandoah");
+            return new DataReaderShenandoah(gcResource, in);
         }
         return null;
     }

--- a/src/main/java/com/tagtraum/perf/gcviewer/imp/DataReaderShenandoah.java
+++ b/src/main/java/com/tagtraum/perf/gcviewer/imp/DataReaderShenandoah.java
@@ -23,14 +23,14 @@ import java.util.stream.Stream;
  * [0.730s][info][gc,start     ] GC(0) Pause Init Mark
  * [0.731s][info][gc           ] GC(0) Pause Init Mark 1.021ms
  * [0.731s][info][gc,start     ] GC(0) Concurrent marking
- * [0.735s][info][gc           ] GC(0) Concurrent marking 74M->74M(128M) 3.688ms
+ * [0.735s][info][gc           ] GC(0) Concurrent marking 74M-&gt;74M(128M) 3.688ms
  * [0.735s][info][gc,start     ] GC(0) Pause Final Mark
- * [0.736s][info][gc           ] GC(0) Pause Final Mark 74M->76M(128M) 0.811ms
+ * [0.736s][info][gc           ] GC(0) Pause Final Mark 74M-&gt;76M(128M) 0.811ms
  * [0.736s][info][gc,start     ] GC(0) Concurrent evacuation
  * ...
  * [29.628s][info][gc            ] Cancelling concurrent GC: Allocation Failure
  * ... skipping detailed messages as those aren't parsed yet
- * [43.948s][info][gc             ] GC(831) Pause Full (Allocation Failure) 7943M->6013M(8192M) 14289.335ms
+ * [43.948s][info][gc             ] GC(831) Pause Full (Allocation Failure) 7943M-&gt;6013M(8192M) 14289.335ms
  */
 public class DataReaderShenandoah extends AbstractDataReader {
 

--- a/src/main/java/com/tagtraum/perf/gcviewer/imp/DataReaderShenandoah.java
+++ b/src/main/java/com/tagtraum/perf/gcviewer/imp/DataReaderShenandoah.java
@@ -1,0 +1,179 @@
+package com.tagtraum.perf.gcviewer.imp;
+
+import com.tagtraum.perf.gcviewer.model.AbstractGCEvent;
+import com.tagtraum.perf.gcviewer.model.GCModel;
+import com.tagtraum.perf.gcviewer.model.GCResource;
+import com.tagtraum.perf.gcviewer.model.ShenandoahGCEvent;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.LineNumberReader;
+import java.io.UnsupportedEncodingException;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class DataReaderShenandoah extends AbstractDataReader {
+    /**
+     * Currently only parsing 5 main messages for GCViewer with default decorations.
+     * Initial mark, concurrent mark, final mark, concurrent evacuation
+     *
+     * Example Format
+     * [0.730s][info][gc,start     ] GC(0) Pause Init Mark
+     * [0.731s][info][gc           ] GC(0) Pause Init Mark 1.021ms
+     * [0.731s][info][gc,start     ] GC(0) Concurrent marking
+     * [0.735s][info][gc           ] GC(0) Concurrent marking 74M->74M(128M) 3.688ms
+     * [0.735s][info][gc,start     ] GC(0) Pause Final Mark
+     * [0.736s][info][gc           ] GC(0) Pause Final Mark 74M->76M(128M) 0.811ms
+     * [0.736s][info][gc,start     ] GC(0) Concurrent evacuation
+     * ...
+     * [29.628s][info][gc            ] Cancelling concurrent GC: Allocation Failure
+     * ... skipping detailed messages as those aren't parsed yet
+     * [43.948s][info][gc             ] GC(831) Pause Full (Allocation Failure) 7943M->6013M(8192M) 14289.335ms
+     */
+
+    // Input: [0.693s][info][gc           ] GC(0) Pause Init Mark 1.070ms
+    // Group 1: 0.693
+    // Group 2: 1.070
+    // Regex without breaking: ^\[([0-9]+\.[0-9]+).*[ ]([0-9]+\.[0-9]+)
+    private static final Pattern PATTERN_INIT_MARK = Pattern.compile("^\\[([0-9]+\\.[0-9]+).*[ ]([0-9]+\\.[0-9]+)");
+
+    // Input: [13.522s][info][gc            ] GC(708) Concurrent evacuation  4848M->4855M(4998M) 2.872ms
+    // Group 1: 13.522
+    // Group 2: 4848M->4855M(4998M)
+    // Group 3: 2.872
+    // Regex without breaking: ^\[([0-9]+\.[0-9]+).*[ ]([0-9]+[BKMG]\-\>[0-9]+[BKMG]\([0-9]+[BKMG]\)) ([0-9]+\.[0-9]+)
+    private static final Pattern PATTERN_GENERIC_LINE = Pattern.compile("^\\[([0-9]+\\.[0-9]+)" +
+            ".*[ ]([0-9]+[BKMG]\\-\\>[0-9]+[BKMG]\\([0-9]+[BKMG]\\)) " +
+            "([0-9]+\\.[0-9]+)");
+
+    // Input: 4848M->4855M(4998M)
+    // Group 1: 4848
+    // Group 2: 4855
+    // Group 3: 4998
+    // Regex without breaking: ([0-9]+)[BKMG]\-\>([0-9]+)[BKMG]\(([0-9]+)[BKMG]\)
+    private static final Pattern PATTERN_HEAP_CHANGES = Pattern.compile("([0-9]+)[BKMG]->([0-9]+)[BKMG]\\(([0-9]+)[BKMG]\\)");
+
+    private static final int INIT_MARK_TIMESTAMP = 1;
+    private static final int INIT_MARK_DURATION = 2;
+    private static final int GENERIC_MARK_TIMESTAMP = 1;
+    private static final int GENERIC_MARK_MEMORY = 2;
+    private static final int GENERIC_MARK_DURATION = 3;
+    private static final int HEAP_BEFORE = 1;
+    private static final int HEAP_AFTER = 2;
+    private static final int HEAP_CURRENT_TOTAL = 3;
+
+    private static final List<String> EXCLUDE_STRINGS = new LinkedList<>();
+
+    static {
+        EXCLUDE_STRINGS.add("Using Shenandoah");
+        EXCLUDE_STRINGS.add("Cancelling concurrent GC: Stopping VM");
+        EXCLUDE_STRINGS.add("[gc,start");
+        EXCLUDE_STRINGS.add("[gc,ergo");
+        EXCLUDE_STRINGS.add("[gc,stringtable");
+        EXCLUDE_STRINGS.add("[gc,init");
+        EXCLUDE_STRINGS.add("[gc,heap");
+        EXCLUDE_STRINGS.add("[gc,stats");
+        EXCLUDE_STRINGS.add("[pagesize");
+        EXCLUDE_STRINGS.add("[class");
+        EXCLUDE_STRINGS.add("[os");
+        EXCLUDE_STRINGS.add("[startuptime");
+        EXCLUDE_STRINGS.add("[os,thread");
+        EXCLUDE_STRINGS.add("[gc,heap,exit");
+        EXCLUDE_STRINGS.add("Concurrent reset bitmaps");
+        EXCLUDE_STRINGS.add("Cancelling concurrent GC: Allocation Failure");
+        EXCLUDE_STRINGS.add("Phase "); // Ignore Allocation failure standalone messages, only parse the total
+    }
+
+    protected DataReaderShenandoah(GCResource gcResource, InputStream in) throws UnsupportedEncodingException {
+        super(gcResource, in);
+    }
+
+    @Override
+    public GCModel read() throws IOException {
+        if (getLogger().isLoggable(Level.INFO)) getLogger().info("Reading Shenandoah format...");
+
+        GCModel model = new GCModel();
+        model.setFormat(GCModel.Format.RED_HAT_SHENANDOAH_GC);
+
+        try (LineNumberReader in = this.in) {
+            String line;
+            while ((line = in.readLine()) != null) {
+                if ("".equals(line) || lineInExcludedStrings(line)) continue;
+                model.add(parseShenandoahEvent(line));
+            }
+        }
+
+        return model;
+    }
+
+    private AbstractGCEvent<?> parseShenandoahEvent(String line) {
+        ShenandoahGCEvent event = new ShenandoahGCEvent();
+
+        if (line.contains("Init Mark")) {
+            Matcher matcher = PATTERN_INIT_MARK.matcher(line);
+            if (matcher.find()) {
+                event.setTimestamp(Double.parseDouble(matcher.group(INIT_MARK_TIMESTAMP)));
+                event.setPause(Double.parseDouble(matcher.group(INIT_MARK_DURATION)));
+                setEventTypes(event, AbstractGCEvent.Type.SHEN_CONCURRENT_INIT_MARK);
+            } else {
+                logMessage("Failed to match init mark line: " + line, Level.WARNING);
+            }
+        } else {
+            Matcher matcher = PATTERN_GENERIC_LINE.matcher(line);
+            if (matcher.find()) {
+                if (line.contains("Final Mark")) {
+                    setEventTypes(event, AbstractGCEvent.Type.SHEN_CONCURRENT_FINAL_MARK);
+                } else if (line.contains("Concurrent marking")) {
+                    setEventTypes(event, AbstractGCEvent.Type.SHEN_CONCURRENT_CONC_MARK);
+                    event.setConcurrency(true);
+                } else if (line.contains("Concurrent evacuation")) {
+                    setEventTypes(event, AbstractGCEvent.Type.SHEN_CONCURRENT_CONC_EVAC);
+                    event.setConcurrency(true);
+                } else if (line.contains("Pause Full (Allocation Failure)")) {
+                    setEventTypes(event, AbstractGCEvent.Type.SHEN_CONCURRENT_ALLOC_FAILURE);
+                }
+                event.setPause(Double.parseDouble(matcher.group(GENERIC_MARK_DURATION)));
+                event.setTimestamp(Double.parseDouble(matcher.group(GENERIC_MARK_TIMESTAMP)));
+                addHeapDetailsToEvent(event, matcher.group(GENERIC_MARK_MEMORY));
+            } else {
+                logMessage("Failed to match generic GC line: " + line, Level.WARNING);
+            }
+        }
+        return event;
+    }
+
+    /**
+     * @param event        GC event to which the heap change information is added
+     * @param memoryString Memory changes in format 100M->80M(120M) where 100M-before, 80M-after, 120M-max
+     */
+    private void addHeapDetailsToEvent(ShenandoahGCEvent event, String memoryString) {
+        Matcher matcher = PATTERN_HEAP_CHANGES.matcher(memoryString);
+        if (matcher.find()) {
+            event.setPreUsed(Integer.parseInt(matcher.group(HEAP_BEFORE)));
+            event.setPostUsed(Integer.parseInt(matcher.group(HEAP_AFTER)));
+            event.setTotal(Integer.parseInt(matcher.group(HEAP_CURRENT_TOTAL)));
+            event.setExtendedType(event.getExtendedType());
+        } else {
+            logMessage("Failed to find heap details from line: " + memoryString, Level.WARNING);
+        }
+    }
+
+
+    private void setEventTypes(ShenandoahGCEvent event, AbstractGCEvent.Type type) {
+        event.setType(type);
+        event.setExtendedType(AbstractGCEvent.ExtendedType.lookup(type));
+    }
+
+    private boolean lineInExcludedStrings(String line) {
+        return EXCLUDE_STRINGS.stream().anyMatch(line::contains);
+    }
+
+    private void logMessage(String message, Level level) {
+        if (getLogger().isLoggable(level)) {
+            getLogger().info(message);
+        }
+    }
+}

--- a/src/main/java/com/tagtraum/perf/gcviewer/imp/DataReaderShenandoah.java
+++ b/src/main/java/com/tagtraum/perf/gcviewer/imp/DataReaderShenandoah.java
@@ -69,7 +69,8 @@ public class DataReaderShenandoah extends AbstractDataReader {
     private static final List<String> EXCLUDE_STRINGS = Arrays.asList("Using Shenandoah", "Cancelling concurrent GC",
             "[gc,start", "[gc,ergo", "[gc,stringtable", "[gc,init", "[gc,heap", "[pagesize", "[class", "[os", "[startuptime",
             "[os,thread", "[gc,heap,exit", "Cancelling concurrent GC: Allocation Failure", "Phase ",
-            "[gc,stats", "[biasedlocking", "[logging", "[verification", "[modules,startuptime", "[safepoint");
+            "[gc,stats", "[biasedlocking", "[logging", "[verification", "[modules,startuptime", "[safepoint", "[stacktrace",
+            "[exceptions", "thrown", "at bci", "for thread");
 
     protected DataReaderShenandoah(GCResource gcResource, InputStream in) throws UnsupportedEncodingException {
         super(gcResource, in);
@@ -93,7 +94,6 @@ public class DataReaderShenandoah extends AbstractDataReader {
         Matcher noHeapMatcher = PATTERN_WITHOUT_HEAP.matcher(line);
         Matcher withHeapMatcher = PATTERN_WITH_HEAP.matcher(line);
         if (noHeapMatcher.find()) {
-            System.out.println(line);
             if (line.contains("Init Mark")) {
                 setEventTypes(event, AbstractGCEvent.Type.SHEN_STW_INIT_MARK);
             } else if (line.contains("Concurrent reset bitmaps")) {

--- a/src/main/java/com/tagtraum/perf/gcviewer/model/AbstractGCEvent.java
+++ b/src/main/java/com/tagtraum/perf/gcviewer/model/AbstractGCEvent.java
@@ -90,7 +90,9 @@ public abstract class AbstractGCEvent<T extends AbstractGCEvent<T>> implements S
     }
 
     public boolean isStopTheWorld() {
-        boolean isStopTheWorld = getExtendedType().getConcurrency() == Concurrency.SERIAL;
+        boolean isStopTheWorld = getExtendedType().getConcurrency() == Concurrency.SERIAL ||
+                getExtendedType().getType() == Type.SHEN_CONCURRENT_INIT_MARK ||
+                getExtendedType().getType() == Type.SHEN_CONCURRENT_FINAL_MARK;
         if (details != null) {
             for (T detailEvent : details) {
                 if (!isStopTheWorld) {
@@ -162,6 +164,7 @@ public abstract class AbstractGCEvent<T extends AbstractGCEvent<T>> implements S
         if (getExtendedType().getGeneration().compareTo(Generation.ALL) == 0) {
             return true;
         }
+        if (getExtendedType().getType().getName().contains("S"))
 
         if (details != null) {
             // the assumption is, that a full collection is everything, that collects from more
@@ -503,7 +506,16 @@ public abstract class AbstractGCEvent<T extends AbstractGCEvent<T>> implements S
         public static final Type G1_CONCURRENT_COUNT_END = new Type("GC concurrent-count-end", Generation.TENURED, Concurrency.CONCURRENT, GcPattern.GC_PAUSE);
         public static final Type G1_CONCURRENT_CLEANUP_START = new Type("GC concurrent-cleanup-start", Generation.TENURED, Concurrency.CONCURRENT, GcPattern.GC);
         public static final Type G1_CONCURRENT_CLEANUP_END = new Type("GC concurrent-cleanup-end", Generation.TENURED, Concurrency.CONCURRENT, GcPattern.GC_PAUSE);
-        
+
+        // Shenandoah types of Generation.TENURED since Generation.ALL gets ignored apparently (GCEvent.java line 56)
+        public static final Type SHEN_CONCURRENT_INIT_MARK = new Type("GC Initial Mark (STW pause) initial-mark", Generation.TENURED, Concurrency.SERIAL, GcPattern.GC_PAUSE);
+        public static final Type SHEN_CONCURRENT_CONC_MARK = new Type("GC Concurrent marking", Generation.TENURED, Concurrency.CONCURRENT, GcPattern.GC);
+        public static final Type SHEN_CONCURRENT_FINAL_MARK = new Type("GC Final Mark (STW pause)", Generation.TENURED, Concurrency.SERIAL, GcPattern.GC_PAUSE);
+        public static final Type SHEN_CONCURRENT_CONC_EVAC = new Type("GC Concurrent evacuation", Generation.TENURED, Concurrency.CONCURRENT, GcPattern.GC);
+
+        // Allocation failure types
+        public static final Type SHEN_CONCURRENT_ALLOC_FAILURE = new Type("GC Pause Full (Allocation Failure)", Generation.TENURED, Concurrency.CONCURRENT, GcPattern.GC);
+
         // IBM Types
         // TODO: are scavenge always young only??
         public static final Type IBM_AF = new Type("af", Generation.YOUNG);

--- a/src/main/java/com/tagtraum/perf/gcviewer/model/AbstractGCEvent.java
+++ b/src/main/java/com/tagtraum/perf/gcviewer/model/AbstractGCEvent.java
@@ -505,13 +505,14 @@ public abstract class AbstractGCEvent<T extends AbstractGCEvent<T>> implements S
         public static final Type G1_CONCURRENT_CLEANUP_END = new Type("GC concurrent-cleanup-end", Generation.TENURED, Concurrency.CONCURRENT, GcPattern.GC_PAUSE);
 
         // Shenandoah types of Generation.TENURED since Generation.ALL gets ignored apparently (GCEvent.java line 56)
-        public static final Type SHEN_CONCURRENT_INIT_MARK = new Type("GC Initial Mark (STW pause) initial-mark", Generation.TENURED, Concurrency.SERIAL, GcPattern.GC_PAUSE);
-        public static final Type SHEN_CONCURRENT_CONC_MARK = new Type("GC Concurrent marking", Generation.TENURED, Concurrency.CONCURRENT, GcPattern.GC);
-        public static final Type SHEN_CONCURRENT_FINAL_MARK = new Type("GC Final Mark (STW pause)", Generation.TENURED, Concurrency.SERIAL, GcPattern.GC_PAUSE);
-        public static final Type SHEN_CONCURRENT_CONC_EVAC = new Type("GC Concurrent evacuation", Generation.TENURED, Concurrency.CONCURRENT, GcPattern.GC);
+        // STW pauses
+        public static final Type SHEN_STW_INIT_MARK = new Type("GC Pause Initial Mark (STW pause) initial-mark", Generation.TENURED, Concurrency.SERIAL, GcPattern.GC_PAUSE);
+        public static final Type SHEN_STW_FINAL_MARK = new Type("GC Pause Final Mark (STW pause)", Generation.TENURED, Concurrency.SERIAL, GcPattern.GC_PAUSE);
+        public static final Type SHEN_STW_ALLOC_FAILURE = new Type("GC Pause Full (Allocation Failure)", Generation.TENURED, Concurrency.SERIAL, GcPattern.GC_PAUSE);
 
-        // Allocation failure types
-        public static final Type SHEN_CONCURRENT_ALLOC_FAILURE = new Type("GC Pause Full (Allocation Failure)", Generation.TENURED, Concurrency.SERIAL, GcPattern.GC);
+        public static final Type SHEN_CONCURRENT_CONC_MARK = new Type("GC Concurrent marking", Generation.TENURED, Concurrency.CONCURRENT, GcPattern.GC);
+        public static final Type SHEN_CONCURRENT_CONC_EVAC = new Type("GC Concurrent evacuation", Generation.TENURED, Concurrency.CONCURRENT, GcPattern.GC);
+        public static final Type SHEN_CONCURRENT_CONC_RESET = new Type("GC Concurret reset bitmaps", Generation.TENURED, Concurrency.CONCURRENT, GcPattern.GC);
 
         // IBM Types
         // TODO: are scavenge always young only??

--- a/src/main/java/com/tagtraum/perf/gcviewer/model/AbstractGCEvent.java
+++ b/src/main/java/com/tagtraum/perf/gcviewer/model/AbstractGCEvent.java
@@ -90,9 +90,7 @@ public abstract class AbstractGCEvent<T extends AbstractGCEvent<T>> implements S
     }
 
     public boolean isStopTheWorld() {
-        boolean isStopTheWorld = getExtendedType().getConcurrency() == Concurrency.SERIAL ||
-                getExtendedType().getType() == Type.SHEN_CONCURRENT_INIT_MARK ||
-                getExtendedType().getType() == Type.SHEN_CONCURRENT_FINAL_MARK;
+        boolean isStopTheWorld = getExtendedType().getConcurrency() == Concurrency.SERIAL;
         if (details != null) {
             for (T detailEvent : details) {
                 if (!isStopTheWorld) {
@@ -164,7 +162,6 @@ public abstract class AbstractGCEvent<T extends AbstractGCEvent<T>> implements S
         if (getExtendedType().getGeneration().compareTo(Generation.ALL) == 0) {
             return true;
         }
-        if (getExtendedType().getType().getName().contains("S"))
 
         if (details != null) {
             // the assumption is, that a full collection is everything, that collects from more
@@ -514,7 +511,7 @@ public abstract class AbstractGCEvent<T extends AbstractGCEvent<T>> implements S
         public static final Type SHEN_CONCURRENT_CONC_EVAC = new Type("GC Concurrent evacuation", Generation.TENURED, Concurrency.CONCURRENT, GcPattern.GC);
 
         // Allocation failure types
-        public static final Type SHEN_CONCURRENT_ALLOC_FAILURE = new Type("GC Pause Full (Allocation Failure)", Generation.TENURED, Concurrency.CONCURRENT, GcPattern.GC);
+        public static final Type SHEN_CONCURRENT_ALLOC_FAILURE = new Type("GC Pause Full (Allocation Failure)", Generation.TENURED, Concurrency.SERIAL, GcPattern.GC);
 
         // IBM Types
         // TODO: are scavenge always young only??

--- a/src/main/java/com/tagtraum/perf/gcviewer/model/AbstractGCEvent.java
+++ b/src/main/java/com/tagtraum/perf/gcviewer/model/AbstractGCEvent.java
@@ -511,6 +511,7 @@ public abstract class AbstractGCEvent<T extends AbstractGCEvent<T>> implements S
         public static final Type SHEN_STW_INIT_UPDATE_REFS = new Type("GC Pause Init Update Refs (STW pause)", Generation.TENURED, Concurrency.SERIAL, GcPattern.GC_PAUSE);
         public static final Type SHEN_STW_FINAL_UPDATE_REFS = new Type("GC Pause Final Update Refs", Generation.TENURED, Concurrency.SERIAL, GcPattern.GC_PAUSE);
         public static final Type SHEN_STW_ALLOC_FAILURE = new Type("GC Pause Full (Allocation Failure)", Generation.TENURED, Concurrency.SERIAL, GcPattern.GC_PAUSE);
+        public static final Type SHEN_STW_SYSTEM_GC = new Type("GC Pause Full (System.gc())", Generation.TENURED, Concurrency.SERIAL, GcPattern.GC_PAUSE);
         // Concurrent events
         public static final Type SHEN_CONCURRENT_CONC_MARK = new Type("GC Concurrent marking", Generation.TENURED, Concurrency.CONCURRENT, GcPattern.GC);
         public static final Type SHEN_CONCURRENT_CONC_EVAC = new Type("GC Concurrent evacuation", Generation.TENURED, Concurrency.CONCURRENT, GcPattern.GC);

--- a/src/main/java/com/tagtraum/perf/gcviewer/model/AbstractGCEvent.java
+++ b/src/main/java/com/tagtraum/perf/gcviewer/model/AbstractGCEvent.java
@@ -505,14 +505,18 @@ public abstract class AbstractGCEvent<T extends AbstractGCEvent<T>> implements S
         public static final Type G1_CONCURRENT_CLEANUP_END = new Type("GC concurrent-cleanup-end", Generation.TENURED, Concurrency.CONCURRENT, GcPattern.GC_PAUSE);
 
         // Shenandoah types of Generation.TENURED since Generation.ALL gets ignored apparently (GCEvent.java line 56)
-        // STW pauses
-        public static final Type SHEN_STW_INIT_MARK = new Type("GC Pause Initial Mark (STW pause) initial-mark", Generation.TENURED, Concurrency.SERIAL, GcPattern.GC_PAUSE);
+        // STW pause events
+        public static final Type SHEN_STW_INIT_MARK = new Type("GC Pause Initial Mark (STW pause)", Generation.TENURED, Concurrency.SERIAL, GcPattern.GC_PAUSE);
         public static final Type SHEN_STW_FINAL_MARK = new Type("GC Pause Final Mark (STW pause)", Generation.TENURED, Concurrency.SERIAL, GcPattern.GC_PAUSE);
+        public static final Type SHEN_STW_INIT_UPDATE_REFS = new Type("GC Pause Init Update Refs (STW pause)", Generation.TENURED, Concurrency.SERIAL, GcPattern.GC_PAUSE);
+        public static final Type SHEN_STW_FINAL_UPDATE_REFS = new Type("GC Pause Final Update Refs", Generation.TENURED, Concurrency.SERIAL, GcPattern.GC_PAUSE);
         public static final Type SHEN_STW_ALLOC_FAILURE = new Type("GC Pause Full (Allocation Failure)", Generation.TENURED, Concurrency.SERIAL, GcPattern.GC_PAUSE);
-
+        // Concurrent events
         public static final Type SHEN_CONCURRENT_CONC_MARK = new Type("GC Concurrent marking", Generation.TENURED, Concurrency.CONCURRENT, GcPattern.GC);
         public static final Type SHEN_CONCURRENT_CONC_EVAC = new Type("GC Concurrent evacuation", Generation.TENURED, Concurrency.CONCURRENT, GcPattern.GC);
-        public static final Type SHEN_CONCURRENT_CONC_RESET = new Type("GC Concurret reset bitmaps", Generation.TENURED, Concurrency.CONCURRENT, GcPattern.GC);
+        public static final Type SHEN_CONCURRENT_CONC_RESET_BITMAPS = new Type("GC Concurrent reset bitmaps", Generation.TENURED, Concurrency.CONCURRENT, GcPattern.GC);
+        public static final Type SHEN_CONCURRENT_CONC_UPDATE_REFS = new Type("GC Concurrent update references", Generation.TENURED, Concurrency.CONCURRENT, GcPattern.GC);
+        public static final Type SHEN_CONCURRENT_PRECLEANING = new Type("GC Concurrent precleaning", Generation.TENURED, Concurrency.CONCURRENT, GcPattern.GC);
 
         // IBM Types
         // TODO: are scavenge always young only??

--- a/src/main/java/com/tagtraum/perf/gcviewer/model/GCModel.java
+++ b/src/main/java/com/tagtraum/perf/gcviewer/model/GCModel.java
@@ -421,29 +421,26 @@ public class GCModel implements Serializable {
             if (event.isInitialMark()) {
                 updateInitiatingOccupancyFraction(event);
             }
-            if (size() > 1 && allEvents.get(allEvents.size() - 2).isConcurrentCollectionEnd()) {
-                updatePostConcurrentCycleUsedSizes(event);
-            }
+
             if (firstPauseTimeStamp == 0) {
                 firstPauseTimeStamp = event.getTimestamp();
             }
+
             freedMemory += event.getPreUsed() - event.getPostUsed();
             updateHeapSizes(event);
             updateGcPauseInterval(event);
             updatePromotion(event);
 
             if (!event.isStopTheWorld()) {
+                // handle concurrent events
                 DoubleData pauses = getDoubleData(event.getExtendedType().getName(), concurrentGcEventPauses);
                 pauses.add(event.getPause());
                 currentNoFullGCEvents.add(event);
-                postConcurrentCycleUsedHeapSizes.add(event.getPreUsed()); // the method update
-                //postGCUsedMemory.add(event.getPostUsed());
-                //currentPostGCSlope.addPoint(event.getTimestamp(), event.getPostUsed());
-                //currentRelativePostGCIncrease.addPoint(currentRelativePostGCIncrease.getPointCount(), event.getPostUsed());
+                postConcurrentCycleUsedHeapSizes.add(event.getPreUsed());
                 gcEvents.add(event);
-                //freedMemoryByGC.add(event.getPreUsed() - event.getPostUsed());
                 gcPause.add(event.getPause());
             } else {
+                // handle STW events
                 DoubleData pauses = getDoubleData(event.getTypeAsString(), fullGcEventPauses);
                 pauses.add(event.getPause());
                 updateFullGcPauseInterval(event);

--- a/src/main/java/com/tagtraum/perf/gcviewer/model/GCModel.java
+++ b/src/main/java/com/tagtraum/perf/gcviewer/model/GCModel.java
@@ -436,7 +436,7 @@ public class GCModel implements Serializable {
                 DoubleData pauses = getDoubleData(event.getExtendedType().getName(), concurrentGcEventPauses);
                 pauses.add(event.getPause());
                 currentNoFullGCEvents.add(event);
-                updatePostConcurrentCycleUsedSizes(event);
+                postConcurrentCycleUsedHeapSizes.add(event.getPreUsed()); // the method update
                 //postGCUsedMemory.add(event.getPostUsed());
                 //currentPostGCSlope.addPoint(event.getTimestamp(), event.getPostUsed());
                 //currentRelativePostGCIncrease.addPoint(currentRelativePostGCIncrease.getPointCount(), event.getPostUsed());
@@ -569,9 +569,7 @@ public class GCModel implements Serializable {
             afterConcurrentEvent = event.getTenured();
         }
 
-        if (!(event instanceof ShenandoahGCEvent)) {
-            postConcurrentCycleUsedTenuredSizes.add(afterConcurrentEvent.getPreUsed());
-        }
+        postConcurrentCycleUsedTenuredSizes.add(afterConcurrentEvent.getPreUsed());
         postConcurrentCycleUsedHeapSizes.add(event.getPreUsed());
     }
 

--- a/src/main/java/com/tagtraum/perf/gcviewer/model/GCModel.java
+++ b/src/main/java/com/tagtraum/perf/gcviewer/model/GCModel.java
@@ -435,13 +435,13 @@ public class GCModel implements Serializable {
             if (!event.isStopTheWorld()) {
                 DoubleData pauses = getDoubleData(event.getExtendedType().getName(), concurrentGcEventPauses);
                 pauses.add(event.getPause());
-                postGCUsedMemory.add(event.getPostUsed());
                 currentNoFullGCEvents.add(event);
-                //lastPauseTimeStamp = event.getTimestamp();
-                currentPostGCSlope.addPoint(event.getTimestamp(), event.getPostUsed());
-                currentRelativePostGCIncrease.addPoint(currentRelativePostGCIncrease.getPointCount(), event.getPostUsed());
+                updatePostConcurrentCycleUsedSizes(event);
+                //postGCUsedMemory.add(event.getPostUsed());
+                //currentPostGCSlope.addPoint(event.getTimestamp(), event.getPostUsed());
+                //currentRelativePostGCIncrease.addPoint(currentRelativePostGCIncrease.getPointCount(), event.getPostUsed());
                 gcEvents.add(event);
-                freedMemoryByGC.add(event.getPreUsed() - event.getPostUsed());
+                //freedMemoryByGC.add(event.getPreUsed() - event.getPostUsed());
                 gcPause.add(event.getPause());
             } else {
                 DoubleData pauses = getDoubleData(event.getTypeAsString(), fullGcEventPauses);
@@ -569,7 +569,9 @@ public class GCModel implements Serializable {
             afterConcurrentEvent = event.getTenured();
         }
 
-        postConcurrentCycleUsedTenuredSizes.add(afterConcurrentEvent.getPreUsed());
+        if (!(event instanceof ShenandoahGCEvent)) {
+            postConcurrentCycleUsedTenuredSizes.add(afterConcurrentEvent.getPreUsed());
+        }
         postConcurrentCycleUsedHeapSizes.add(event.getPreUsed());
     }
 

--- a/src/main/java/com/tagtraum/perf/gcviewer/model/ShenandoahGCEvent.java
+++ b/src/main/java/com/tagtraum/perf/gcviewer/model/ShenandoahGCEvent.java
@@ -6,14 +6,13 @@ package com.tagtraum.perf.gcviewer.model;
  */
 public class ShenandoahGCEvent extends GCEvent {
 
-    /** Used before GC in KB */
+    /** Heap usage in KB, override for convertion from MB to KB */
     private int preUsed;
-
-    /** Used after GC in KB */
     private int postUsed;
-
-    /** Capacity in KB */
     private int total;
+
+    /** Override GCEvent as Shenandoah pause times are in milliseconds and GCViewer displays seconds */
+    private double pause;
 
     /** By default events are not concurrent, must be set so */
     private boolean concurrency;
@@ -30,28 +29,46 @@ public class ShenandoahGCEvent extends GCEvent {
         this.concurrency = concurrency;
     }
 
+    @Override
     public void setPreUsed(int preUsed) {
-        this.preUsed = preUsed;
+        this.preUsed = preUsed * 1000;
     }
 
+    @Override
     public void setPostUsed(int postUsed) {
-        this.postUsed = postUsed;
+        this.postUsed = postUsed * 1000;
     }
 
+    @Override
     public void setTotal(int total) {
-        this.total = total;
+        this.total = total * 1000;
     }
 
+    @Override
     public int getPreUsed() {
         return preUsed;
     }
 
+    @Override
     public int getPostUsed() {
         return postUsed;
     }
 
+    @Override
     public int getTotal() {
         return total;
     }
+
+    @Override
+    public double getPause() {
+        return pause;
+    }
+
+    @Override
+    public void setPause(double pause) {
+        this.pause = pause / 1000;
+    }
+
+
 
 }

--- a/src/main/java/com/tagtraum/perf/gcviewer/model/ShenandoahGCEvent.java
+++ b/src/main/java/com/tagtraum/perf/gcviewer/model/ShenandoahGCEvent.java
@@ -1,0 +1,57 @@
+package com.tagtraum.perf.gcviewer.model;
+
+/**
+ * Created by Mart on 19/04/2017.
+ * GC Event class that holds extra information about concurrency and heap.
+ */
+public class ShenandoahGCEvent extends GCEvent {
+
+    /** Used before GC in KB */
+    private int preUsed;
+
+    /** Used after GC in KB */
+    private int postUsed;
+
+    /** Capacity in KB */
+    private int total;
+
+    /** By default events are not concurrent, must be set so */
+    private boolean concurrency;
+
+    public ShenandoahGCEvent() {
+        concurrency = false;
+    }
+
+    public boolean isConcurrent() {
+        return concurrency;
+    }
+
+    public void setConcurrency(boolean concurrency) {
+        this.concurrency = concurrency;
+    }
+
+    public void setPreUsed(int preUsed) {
+        this.preUsed = preUsed;
+    }
+
+    public void setPostUsed(int postUsed) {
+        this.postUsed = postUsed;
+    }
+
+    public void setTotal(int total) {
+        this.total = total;
+    }
+
+    public int getPreUsed() {
+        return preUsed;
+    }
+
+    public int getPostUsed() {
+        return postUsed;
+    }
+
+    public int getTotal() {
+        return total;
+    }
+
+}

--- a/src/main/java/com/tagtraum/perf/gcviewer/view/ModelMetricsPanel.java
+++ b/src/main/java/com/tagtraum/perf/gcviewer/view/ModelMetricsPanel.java
@@ -1,25 +1,17 @@
 package com.tagtraum.perf.gcviewer.view;
 
-import java.awt.GridBagConstraints;
-import java.awt.GridBagLayout;
-import java.awt.Insets;
-import java.text.DateFormat;
-import java.text.NumberFormat;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.Map;
-
-import javax.swing.BorderFactory;
-import javax.swing.BoxLayout;
-import javax.swing.JLabel;
-import javax.swing.JPanel;
-import javax.swing.JTabbedPane;
-
 import com.tagtraum.perf.gcviewer.model.GCModel;
 import com.tagtraum.perf.gcviewer.util.LocalisationHelper;
 import com.tagtraum.perf.gcviewer.util.MemoryFormat;
 import com.tagtraum.perf.gcviewer.util.TimeFormat;
 
+import javax.swing.*;
+import java.awt.*;
+import java.text.DateFormat;
+import java.text.NumberFormat;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
 /**
  * Panel that contains characteristic data about the gc file.
  *
@@ -394,7 +386,7 @@ public class ModelMetricsPanel extends JTabbedPane {
             boolean fullGcPauseIntervalAvailable = model.getFullGCPauseInterval().getN() > 0;
             boolean pauseIntervalDataAvailable = model.getPauseInterval().getN() > 0; // fix for "Exception if only one GC log line in file"
             boolean vmOperationsAvailable = model.getVmOperationPause().getN() > 0;
-            
+
             updateValue(LocalisationHelper.getString("data_panel_acc_pauses"), 
             		gcTimeFormatter.format(model.getPause().getSum()) + "s", 
             		true);
@@ -455,7 +447,7 @@ public class ModelMetricsPanel extends JTabbedPane {
             updateValue(LocalisationHelper.getString("data_panel_min_max_gc_pause"), 
             		gcDataAvailable ? pauseFormatter.format(model.getGCPause().getMin()) + "s / " + pauseFormatter.format(model.getGCPause().getMax()) + "s": "n/a", 
             		gcDataAvailable);
-            
+
         }
     }
 
@@ -529,7 +521,7 @@ public class ModelMetricsPanel extends JTabbedPane {
                     Integer.toString(model.getGCPause().getN()), 
                     true);
         	updateValue(LocalisationHelper.getString("data_panel_performance_gc"),
-        			model.getGCPause().getN() > 0 
+        			model.getGCPause().getN() > 0 && model.getFreedMemoryByGC().getN() > 0
         				? footprintFormatter.format(model.getFreedMemoryByGC().getSum()/model.getGCPause().getSum()) + "/s"
         				: "n/a",
         			model.getGCPause().getN() > 0);

--- a/src/test/java/com/tagtraum/perf/gcviewer/imp/TestDataReaderShenandoah.java
+++ b/src/test/java/com/tagtraum/perf/gcviewer/imp/TestDataReaderShenandoah.java
@@ -1,0 +1,74 @@
+package com.tagtraum.perf.gcviewer.imp;
+
+import com.tagtraum.perf.gcviewer.UnittestHelper;
+import com.tagtraum.perf.gcviewer.model.*;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.logging.Level;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Created by Mart on 10/05/2017.
+ */
+public class TestDataReaderShenandoah {
+    private InputStream getInputStream(String fileName) throws IOException {
+        return UnittestHelper.getResourceAsStream(UnittestHelper.FOLDER_OPENJDK, fileName);
+    }
+
+    private DataReader getDataReader(GCResource gcResource) throws IOException {
+        return new DataReaderShenandoah(gcResource, getInputStream(gcResource.getResourceName()));
+    }
+
+    @Test
+    public void parseBasicEvent() throws Exception {
+        TestLogHandler handler = new TestLogHandler();
+        handler.setLevel(Level.WARNING);
+        GCResource gcResource = new GcResourceFile("SampleShenandoahBasic.txt");
+        gcResource.getLogger().addHandler(handler);
+
+        DataReader reader = getDataReader(gcResource);
+        GCModel model = reader.read();
+
+        assertThat("number of errors", handler.getCount(), is(0));
+        assertThat("size", model.size(), is(5));
+        assertThat("model format", model.getFormat(), is(GCModel.Format.RED_HAT_SHENANDOAH_GC));
+
+        assertThat("heap size after concurrent cycle", model.getPostConcurrentCycleHeapUsedSizes().getMax(), is(122000));
+        assertThat("amount of concurrent pauses", model.getConcurrentEventPauses().size(), is(3));
+        assertThat("amount of STW pauses", model.getFullGcEventPauses().size(), is(2));
+        assertThat("max memory freed during STW pauses", model.getFreedMemoryByFullGC().getMax(), is(34000));
+    }
+
+    /**
+     * In java 8, suddenly the full gc events in G1 got detailed information about the generation
+     * sizes again. Test, that they are parsed correctly.
+     */
+    @Test
+    public void parseAllocationFailure() throws Exception {
+        TestLogHandler handler = new TestLogHandler();
+        handler.setLevel(Level.WARNING);
+        GCResource gcResource = new GcResourceFile("SampleShenandoahAllocationFailure.txt");
+        gcResource.getLogger().addHandler(handler);
+
+        DataReader reader = getDataReader(gcResource);
+        GCModel model = reader.read();
+        GCEvent event = (GCEvent) model.get(0);
+
+        assertThat("number of errors", handler.getCount(), is(0));
+        assertThat("size", model.size(), is(1));
+        assertThat("model format", model.getFormat(), is(GCModel.Format.RED_HAT_SHENANDOAH_GC));
+
+        assertThat("amount of STW pauses", model.getFullGcEventPauses().size(), is(1));
+        assertThat("preUsed matches", event.getPreUsed(), is(7943000));
+        assertThat("postUsed matches", event.getPostUsed(), is(6013000));
+        assertThat("total heap size", event.getTotal(), is(8192000));
+        assertThat("generation", event.getGeneration(), is(AbstractGCEvent.Generation.TENURED));
+        assertThat("timestamp", event.getTimestamp(), is(43.948));
+        assertThat("type", event.getTypeAsString(), is(AbstractGCEvent.Type.SHEN_STW_ALLOC_FAILURE.toString()));
+        assertThat("total pause", model.getPause().getSum(), is(14.289335));
+    }
+}

--- a/src/test/resources/openjdk/SampleShenandoahAllocationFailure.txt
+++ b/src/test/resources/openjdk/SampleShenandoahAllocationFailure.txt
@@ -1,0 +1,12 @@
+[29.628s][info][gc            ] Cancelling concurrent GC: Allocation Failure
+[29.657s][info][gc,start      ] GC(831) Pause Full (Allocation Failure)
+[29.658s][info][gc,phases,start] GC(831) Phase 1: Mark live objects
+[29.675s][info][gc,stringtable ] GC(831) Cleaned string and symbol table, strings: 2736 processed, 110 removed, symbols: 18126 processed, 0 removed
+[29.675s][info][gc,phases      ] GC(831) Phase 1: Mark live objects 17.256ms
+[29.675s][info][gc,phases,start] GC(831) Phase 2: Compute new object addresses
+[29.699s][info][gc,phases      ] GC(831) Phase 2: Compute new object addresses 23.568ms
+[29.699s][info][gc,phases,start] GC(831) Phase 2: Adjust pointers
+[29.725s][info][gc,phases      ] GC(831) Phase 2: Adjust pointers 26.061ms
+[29.725s][info][gc,phases,start] GC(831) Phase 4: Move objects
+[43.914s][info][gc,phases      ] GC(831) Phase 4: Move objects 14078.141ms
+[43.948s][info][gc             ] GC(831) Pause Full (Allocation Failure) 7943M->6013M(8192M) 14289.335ms

--- a/src/test/resources/openjdk/SampleShenandoahBasic.txt
+++ b/src/test/resources/openjdk/SampleShenandoahBasic.txt
@@ -16,4 +16,4 @@
 [193.496s][info][gc,start                ] GC(57) Concurrent evacuation
 [193.498s][info][gc                      ] GC(57) Concurrent evacuation  88M->92M(128M) 2.026ms
 [193.499s][info][gc,start                ] GC(57) Concurrent reset bitmaps
-[193.499s][info][gc                      ] GC(57) Concurrent reset bitmaps 0.282ms
+[193.499s][info][gc                      ] GC(57) Concurrent reset bitmaps 33M->33M(128M) 0.072ms

--- a/src/test/resources/openjdk/SampleShenandoahBasic.txt
+++ b/src/test/resources/openjdk/SampleShenandoahBasic.txt
@@ -1,0 +1,19 @@
+[0.401s][info][gc     ] Using Shenandoah
+[193.492s][info][gc,start                ] GC(57) Pause Init Mark
+[193.492s][info][gc                      ] GC(57) Pause Init Mark 0.412ms
+[193.492s][info][safepoint               ] Total time for which application threads were stopped: 0.0008600 seconds, Stopping threads took: 0.0000370 seconds
+[193.492s][info][gc,start                ] GC(57) Concurrent marking
+[193.495s][info][gc                      ] GC(57) Concurrent marking 122M->122M(128M) 2.447ms
+[193.495s][info][safepoint               ] Application time: 0.0026570 seconds
+[193.495s][info][safepoint,cleanup       ] deflating idle monitors, 0.0000030 secs
+[193.495s][info][safepoint,cleanup       ] updating inline caches, 0.0000000 secs
+[193.495s][info][safepoint,cleanup       ] compilation policy safepoint handler, 0.0000000 secs
+[193.495s][info][safepoint,cleanup       ] mark nmethods, 0.0000110 secs
+[193.495s][info][safepoint,cleanup       ] purging class loader data graph, 0.0000010 secs
+[193.495s][info][gc,start                ] GC(57) Pause Final Mark
+[193.496s][info][gc                      ] GC(57) Pause Final Mark 122M->88M(128M) 0.906ms
+[193.496s][info][safepoint               ] Total time for which application threads were stopped: 0.0012680 seconds, Stopping threads took: 0.0000280 seconds
+[193.496s][info][gc,start                ] GC(57) Concurrent evacuation
+[193.498s][info][gc                      ] GC(57) Concurrent evacuation  88M->92M(128M) 2.026ms
+[193.499s][info][gc,start                ] GC(57) Concurrent reset bitmaps
+[193.499s][info][gc                      ] GC(57) Concurrent reset bitmaps 0.282ms


### PR DESCRIPTION
Added Shenandoah GC log parsing functionality to GCViewer. Currently parsing all 6 main GC events of Shenandoah - initial mark, final mark, concurrent marking, concurrent evacuation, concurrent reset and allocation failure events. Due to concurrent evacuation, some of the statistics displayed in previous parsers are not used in Shenandoah parser.

This is a part of my BSc thesis in University of Tartu, Estonia. 

EDIT: Currently supports the default -Xlog configuration, i.e. the equivalent of: -Xlog:all=warning:stderr:uptime,level,tags.


More info:
[Shenandoah's OpenJDK wiki](https://wiki.openjdk.java.net/display/shenandoah/Main)
[Building latest OpenJDK9 (with Shenandoah GC)](http://arturmkrtchyan.com/building-openjdk-9-on-ubuntu)

Since it might be a hassle to set up OpenJDK just for this, added logs for testing:
[shenandoah_GC_artificial_memory_leak_logs.txt](https://github.com/chewiebug/GCViewer/files/990979/shenandoah_GC_leak_logs.txt)
[shenandoah_GC_logs.txt](https://github.com/chewiebug/GCViewer/files/990978/shenandoah_GC_logs.txt)
