### PR TITLE
Add unit tests for com.tagtraum.perf.gcviewer.math.DoubleData

### DIFF
--- a/src/test/java/com/tagtraum/perf/gcviewer/math/TestDoubleData.java
+++ b/src/test/java/com/tagtraum/perf/gcviewer/math/TestDoubleData.java
@@ -9,6 +9,7 @@ import org.junit.Test;
  * Date: Jan 30, 2002
  * Time: 5:53:55 PM
  * @author <a href="mailto:hs@tagtraum.com">Hendrik Schreiber</a>
+ *
  */
 public class TestDoubleData {
 
@@ -18,14 +19,27 @@ public class TestDoubleData {
         assertEquals("Simple average", 1.5, DoubleData.average(x), 0.0);
     }
 
+    @Test
     public void testSimpleStandardDeviation() throws Exception {
         DoubleData doubleData = new DoubleData();
         doubleData.add(1);
         doubleData.add(1);
         doubleData.add(-1);
         doubleData.add(-1);
-
         assertEquals("Simple std deviation", 1.1547005383792515, doubleData.standardDeviation(), 0.0000001);
     }
 
+    @Test
+    public void testWeightedAverage() {
+        double[] n = {4.0, 5.0, 6.0};
+        int[] weight = {2, 3, 4};
+        assertEquals(5.222, DoubleData.weightedAverage(n, weight), 0.001);
+    }
+
+    @Test
+    public void testWeightedAverageNaN() {
+        double[] n = {Double.NaN};
+        int[] weight = {6, -1, 0, 0};
+        assertEquals(Double.NaN, DoubleData.weightedAverage(n, weight), 0.0);
+    }
 }


### PR DESCRIPTION
I've analysed your codebase and noticed that `com.tagtraum.perf.gcviewer.math.DoubleData` is not fully tested.
I've written some tests for the methods in this class with the help of [Diffblue Cover](https://www.diffblue.com/opensource).

Hopefully, these tests will help you detect any regressions caused by future code changes. If you would find it useful to have additional tests written for this repository, I would be more than happy to look at other classes that you consider important in a subsequent PR.