### PR TITLE
Fix PNG file from current graph is not loading the actual GUI configurations

### DIFF
--- a/src/main/java/com/tagtraum/perf/gcviewer/ctrl/action/Export.java
+++ b/src/main/java/com/tagtraum/perf/gcviewer/ctrl/action/Export.java
@@ -3,12 +3,13 @@ package com.tagtraum.perf.gcviewer.ctrl.action;
 import java.awt.Toolkit;
 import java.awt.event.ActionEvent;
 import java.io.File;
+import java.util.Map;
+import java.util.HashMap;
 
 import javax.swing.AbstractAction;
 import javax.swing.JFileChooser;
 import javax.swing.JOptionPane;
 import javax.swing.KeyStroke;
-import javax.swing.filechooser.FileFilter;
 
 import com.tagtraum.perf.gcviewer.exp.DataWriter;
 import com.tagtraum.perf.gcviewer.exp.DataWriterType;
@@ -86,7 +87,9 @@ public class Export extends AbstractAction {
                         LocalisationHelper.getString("fileexport_dialog_title"),
                         JOptionPane.YES_NO_OPTION)) {
 
-            try (DataWriter writer = DataWriterFactory.getDataWriter(file, dataWriterType)) {
+            Map<String, Object> configuration = new HashMap<>();
+            configuration.put(DataWriterFactory.GC_PREFERENCES, gcViewer.getSelectedGCDocument().getPreferences());
+            try (DataWriter writer = DataWriterFactory.getDataWriter(file, dataWriterType, configuration)) {
                 writer.write(model);
             }
             catch (Exception ioe) {

--- a/src/main/java/com/tagtraum/perf/gcviewer/exp/impl/DataWriterFactory.java
+++ b/src/main/java/com/tagtraum/perf/gcviewer/exp/impl/DataWriterFactory.java
@@ -17,6 +17,7 @@ import com.tagtraum.perf.gcviewer.util.LocalisationHelper;
  * @author <a href="mailto:hs@tagtraum.com">Hendrik Schreiber</a>
  */
 public class DataWriterFactory {
+    public static final String GC_PREFERENCES = "gcPreferences";
 
     /**
      * Standard factory method to retrieve one of the <code>DataWriter</code> implementations.
@@ -53,7 +54,7 @@ public class DataWriterFactory {
             case CSV_TS  : return new CSVTSDataWriter(outputStream);
             case SIMPLE  : return new SimpleGcWriter(outputStream);
             case SUMMARY : return new SummaryDataWriter(outputStream, configuration);
-            case PNG     : return new PNGDataWriter(outputStream);
+            case PNG     : return new PNGDataWriter(outputStream, configuration);
             default : throw new IOException(LocalisationHelper.getString("datawriterfactory_instantiation_failed") + " " + file);
         }
     }

--- a/src/main/java/com/tagtraum/perf/gcviewer/exp/impl/PNGDataWriter.java
+++ b/src/main/java/com/tagtraum/perf/gcviewer/exp/impl/PNGDataWriter.java
@@ -3,10 +3,12 @@ package com.tagtraum.perf.gcviewer.exp.impl;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.Map;
 
 import com.tagtraum.perf.gcviewer.view.SimpleChartRenderer;
 import com.tagtraum.perf.gcviewer.exp.AbstractDataWriter;
 import com.tagtraum.perf.gcviewer.model.GCModel;
+import com.tagtraum.perf.gcviewer.view.model.GCPreferences;
 
 /**
  * PNG data writter
@@ -15,16 +17,33 @@ import com.tagtraum.perf.gcviewer.model.GCModel;
  *
  */
 public class PNGDataWriter extends AbstractDataWriter {
-	private FileOutputStream out;
+	private final FileOutputStream out;
 
-	public PNGDataWriter(OutputStream outputStream) {
-		super(outputStream);
+	/**
+	 * Constructor for PNGDataWriter with additional <code>configuration</code> parameter.
+	 *
+	 * @param outputStream FileOutputStream, file where the image should be written to
+	 * @param configuration Configuration for this PNGDataWriter; expected contents of the parameter:
+	 * <ul>
+	 * <li>String: <code>DataWriterFactory.GC_PREFERENCES</code></li>
+	 * <li>Object: Instance of GCPreferences (E.g. current screen selection for chart)
+	 * </ul>
+	 */
+	public PNGDataWriter(OutputStream outputStream, Map<String, Object> configuration) {
+		super(outputStream, configuration);
 		out = (FileOutputStream)outputStream;
 	}
 
 	@Override
 	public void write(GCModel model) throws IOException {
-		new SimpleChartRenderer().render(model, out);
+		SimpleChartRenderer simpleChartRenderer = new SimpleChartRenderer();
+
+		Object gcPreferences = getConfiguration().get(DataWriterFactory.GC_PREFERENCES);
+		if (gcPreferences instanceof GCPreferences) {
+			simpleChartRenderer.render(model, out, (GCPreferences)gcPreferences);
+		} else {
+			simpleChartRenderer.render(model, out);
+		}
 	}
 
 }

--- a/src/main/java/com/tagtraum/perf/gcviewer/view/SimpleChartRenderer.java
+++ b/src/main/java/com/tagtraum/perf/gcviewer/view/SimpleChartRenderer.java
@@ -22,6 +22,10 @@ public class SimpleChartRenderer {
     public void render(GCModel model, FileOutputStream outputStream) throws IOException {
         GCPreferences gcPreferences = new GCPreferences();
         gcPreferences.load();
+        render(model, outputStream, gcPreferences);
+    }
+
+    public void render(GCModel model, FileOutputStream outputStream, GCPreferences gcPreferences) throws IOException {
         Dimension d = new Dimension(gcPreferences.getWindowWidth(), gcPreferences.getWindowHeight());
 
         BufferedImage image = new BufferedImage(d.width, d.height, BufferedImage.TYPE_INT_RGB);


### PR DESCRIPTION
Firstly, thanks very much for maintaining this project!

I have found this unexpected behaviour while exporting PNG graphics from the current graph.

When a chart is exported as a PNG file, instead of applying the selected View properties for the current chart, the application reloads the definitions found on gcviewer.properties.

This small fix corrects this behaviour, capturing the current view configurations for the chart (E.g. if a specific GC line is visible or not) while exporting a PNG file. 