### PR TITLE
Fix possible java.lang.ArithmeticException when parsing ZGC Log

### DIFF
--- a/src/main/java/com/tagtraum/perf/gcviewer/imp/DataReaderUnifiedJvmLogging.java
+++ b/src/main/java/com/tagtraum/perf/gcviewer/imp/DataReaderUnifiedJvmLogging.java
@@ -505,7 +505,7 @@ public class DataReaderUnifiedJvmLogging extends AbstractDataReader {
         event.setPostUsed(getDataReaderTools().getMemoryInKiloByte(
                 Integer.parseInt(matcher.group(GROUP_MEMORY_PERCENTAGE_AFTER)), matcher.group(GROUP_MEMORY_PERCENTAGE_AFTER_UNIT).charAt(0), matcher.group(GROUP_MEMORY_PERCENTAGE)));
 
-        if (event.getTotal() == 0 && Integer.parseInt(matcher.group(GROUP_MEMORY_PERCENTAGE_BEFORE_PERCENTAGE)) != 0) {
+        if (event.getTotal() == 0 && Integer.parseInt(matcher.group(GROUP_MEMORY_PERCENTAGE_AFTER_PERCENTAGE)) != 0) {
             event.setTotal(event.getPostUsed() / Integer.parseInt(matcher.group(GROUP_MEMORY_PERCENTAGE_AFTER_PERCENTAGE)) * 100);
         }
     }


### PR DESCRIPTION
Reproducible when feeding with a log like

```
[1.592s][info][gc] Using The Z Garbage Collector
[3.321s][info][gc] GC(0) Garbage Collection (Metadata GC Threshold) 332M(2%)->30M(0%)
[5.492s][info][gc] GC(1) Garbage Collection (Metadata GC Threshold) 1044M(6%)->68M(0%)
```