### PR TITLE
Fix IBM J9 parser

### DIFF
--- a/src/main/java/com/tagtraum/perf/gcviewer/ctrl/impl/GCViewerGuiBuilder.java
+++ b/src/main/java/com/tagtraum/perf/gcviewer/ctrl/impl/GCViewerGuiBuilder.java
@@ -232,7 +232,7 @@ public class GCViewerGuiBuilder {
         StayOpenCheckBoxMenuItem menuItemConcurrentGcBeginEnd = new StayOpenCheckBoxMenuItem(LocalisationHelper.getString("main_frame_menuitem_concurrent_collection_begin_end"), true);
         menuItemConcurrentGcBeginEnd.setMnemonic(LocalisationHelper.getString("main_frame_menuitem_mnemonic_concurrent_collection_begin_end").charAt(0));
         menuItemConcurrentGcBeginEnd.setToolTipText(LocalisationHelper.getString("main_frame_menuitem_hint_concurrent_collection_begin_end"));
-        menuItemConcurrentGcBeginEnd.setIcon(ImageHelper.createMonoColoredImageIcon(ConcurrentGcBegionEndRenderer.CONCURRENT_COLLECTION_BEGIN, 20, 20));
+        menuItemConcurrentGcBeginEnd.setIcon(ImageHelper.createMonoColoredImageIcon(ConcurrentGcBeginEndRenderer.CONCURRENT_COLLECTION_BEGIN, 20, 20));
         menuItemConcurrentGcBeginEnd.setActionCommand(GCPreferences.CONCURRENT_COLLECTION_BEGIN_END);
         menuItemConcurrentGcBeginEnd.addActionListener(viewMenuController);
         menuBar.addToViewMenu(GCPreferences.CONCURRENT_COLLECTION_BEGIN_END, menuItemConcurrentGcBeginEnd);

--- a/src/main/java/com/tagtraum/perf/gcviewer/imp/DataReaderIBM_J9_R28.java
+++ b/src/main/java/com/tagtraum/perf/gcviewer/imp/DataReaderIBM_J9_R28.java
@@ -82,6 +82,10 @@ public class DataReaderIBM_J9_R28 extends AbstractDataReader {
                                 assert eventNameStart == null : "eventNameStart was expected to be null, but was " + eventNameStart;
                                 eventNameStart = handleAfStart(eventReader, startElement);
                                 break;
+                            case CONCURRENT_COLLECTION_START:
+                                assert eventNameStart == null : "eventNameStart was expected to be null, but was " + eventNameStart;
+                                eventNameStart = handleConcurrentCollectionStart(eventReader, startElement);
+                                break;
                             case GC_START:
                                 handleGcStart(eventReader, startElement, currentGcEvent, eventNameStart);
                                 break;
@@ -179,7 +183,8 @@ public class DataReaderIBM_J9_R28 extends AbstractDataReader {
         return "af ";
     }
 
-    private void handleConcurrentCollectionStart(XMLEventReader eventReader, StartElement startElement) {
+    private String handleConcurrentCollectionStart(XMLEventReader eventReader, StartElement startElement) {
+        return "concurrent-collection-start ";
     }
 
     private void handleGcStart(XMLEventReader eventReader, StartElement startElement, GCEvent event, String eventNameStart) throws
@@ -195,7 +200,7 @@ public class DataReaderIBM_J9_R28 extends AbstractDataReader {
 
         String currentElementName = "";
         while (eventReader.hasNext() && !currentElementName.equals(GC_START)) {
-            
+
             XMLEvent xmlEvent = eventReader.nextEvent();
             if (xmlEvent.isStartElement()) {
                 StartElement startEl = xmlEvent.asStartElement();
@@ -230,7 +235,6 @@ public class DataReaderIBM_J9_R28 extends AbstractDataReader {
     private void handleGcEnd(XMLEventReader eventReader, GCEvent event) throws XMLStreamException {
         String currentElementName = "";
         while (eventReader.hasNext() && !currentElementName.equals(GC_END)) {
-
             XMLEvent xmlEvent = eventReader.nextEvent();
             if (xmlEvent.isStartElement()) {
                 StartElement startEl = xmlEvent.asStartElement();
@@ -273,11 +277,11 @@ public class DataReaderIBM_J9_R28 extends AbstractDataReader {
         if (attr != null) {
             value = attr.getValue();
         }
-        
+
         return value;
     }
 
     private int toKiloBytes(long bytes) {
-        return (int)Math.rint(bytes / (double)1024);
+        return (int) Math.rint(bytes / (double) 1024);
     }
 }

--- a/src/main/java/com/tagtraum/perf/gcviewer/imp/DataReaderIBM_J9_R28.java
+++ b/src/main/java/com/tagtraum/perf/gcviewer/imp/DataReaderIBM_J9_R28.java
@@ -216,10 +216,13 @@ public class DataReaderIBM_J9_R28 extends AbstractDataReader {
                             event.add(young);
                             break;
                         case "tenure":
-                            GCEvent tenured = new GCEvent();
-                            tenured.setType(Type.lookup("tenure"));
-                            setTotalAndPreUsed(tenured, startEl);
-                            event.add(tenured);
+                            // scavenge prints tenure space but does not change it as it is young only
+                            if(!typeName.contains("scavenge")) {
+                                GCEvent tenured = new GCEvent();
+                                tenured.setType(Type.lookup("tenure"));
+                                setTotalAndPreUsed(tenured, startEl);
+                                event.add(tenured);
+                            }
                             break;
                         // all other are ignored
                     }
@@ -247,7 +250,10 @@ public class DataReaderIBM_J9_R28 extends AbstractDataReader {
                             setPostUsed(event.getYoung(), startEl);
                             break;
                         case "tenure":
-                            setPostUsed(event.getTenured(), startEl);
+                            // scavenge prints tenure space but does not change it as it is young only
+                            if(!event.getTypeAsString().contains("scavenge")) {
+                                setPostUsed(event.getTenured(), startEl);
+                            }
                             break;
                         // all other are ignored
                     }

--- a/src/main/java/com/tagtraum/perf/gcviewer/imp/DataReaderIBM_J9_R28.java
+++ b/src/main/java/com/tagtraum/perf/gcviewer/imp/DataReaderIBM_J9_R28.java
@@ -77,15 +77,15 @@ public class DataReaderIBM_J9_R28 extends AbstractDataReader {
                                 break;
                             case SYS_START:
                                 assert eventNameStart == null : "eventNameStart was expected to be null, but was " + eventNameStart;
-                                eventNameStart = handleSysStart(eventReader, startElement);
+                                eventNameStart = handleSysStart(startElement);
                                 break;
                             case AF_START:
                                 assert eventNameStart == null : "eventNameStart was expected to be null, but was " + eventNameStart;
-                                eventNameStart = handleAfStart(eventReader, startElement);
+                                eventNameStart = handleAfStart();
                                 break;
                             case CONCURRENT_COLLECTION_START:
                                 assert eventNameStart == null : "eventNameStart was expected to be null, but was " + eventNameStart;
-                                eventNameStart = handleConcurrentCollectionStart(eventReader, startElement);
+                                eventNameStart = handleConcurrentCollectionStart();
                                 break;
                             case GC_START:
                                 handleGcStart(eventReader, startElement, currentGcEvent, eventNameStart);
@@ -176,16 +176,16 @@ public class DataReaderIBM_J9_R28 extends AbstractDataReader {
         event.setPause(NumberParser.parseDouble(getAttributeValue(startElement, "durationms")) / 1000);
     }
 
-    private String handleSysStart(XMLEventReader eventReader, StartElement startElement) throws XMLStreamException {
+    private String handleSysStart(StartElement startElement) {
         String reason = getAttributeValue(startElement, "reason");
         return "sys " + (reason != null ? reason + " " : "");
     }
 
-    private String handleAfStart(XMLEventReader eventReader, StartElement startElement) throws XMLStreamException {
+    private String handleAfStart() {
         return "af ";
     }
 
-    private String handleConcurrentCollectionStart(XMLEventReader eventReader, StartElement startElement) {
+    private String handleConcurrentCollectionStart() {
         return "concurrent-collection-start ";
     }
 

--- a/src/main/java/com/tagtraum/perf/gcviewer/model/AbstractGCEvent.java
+++ b/src/main/java/com/tagtraum/perf/gcviewer/model/AbstractGCEvent.java
@@ -709,9 +709,10 @@ public abstract class AbstractGCEvent<T extends AbstractGCEvent<T>> implements S
         public static final Type UJL_ZGC_HEAP_CAPACITY = new Type("Capacity", Generation.TENURED, Concurrency.SERIAL, GcPattern.GC_HEAP_MEMORY_PERCENTAGE);
 
         // IBM Types
-        // TODO: are scavenge always young only??
-        public static final Type IBM_AF = new Type("af", Generation.YOUNG);
         public static final Type IBM_SYS = new Type("sys explicit", Generation.ALL);
+        public static final Type IBM_AF = new Type("af", Generation.YOUNG);
+        // scavenge is young only
+        // see  https://www.ibm.com/support/knowledgecenter/SSYKE2_8.0.0/com.ibm.java.vm.80.doc/docs/mm_gc_pd_verbose_increment.html
         public static final Type IBM_AF_SCAVENGE = new Type("af scavenge", Generation.YOUNG);
         public static final Type IBM_AF_GLOBAL = new Type("af global", Generation.TENURED);
         public static final Type IBM_SYS_GLOBAL = new Type("sys global", Generation.ALL);

--- a/src/main/java/com/tagtraum/perf/gcviewer/model/AbstractGCEvent.java
+++ b/src/main/java/com/tagtraum/perf/gcviewer/model/AbstractGCEvent.java
@@ -277,7 +277,8 @@ public abstract class AbstractGCEvent<T extends AbstractGCEvent<T>> implements S
     }
 
     public boolean isInc() {
-        return getExtendedType().getType() == GCEvent.Type.INC_GC;
+        Type type = getExtendedType().getType();
+        return type == GCEvent.Type.INC_GC || type == Type.IBM_AF_SCAVENGE;
     }
 
     public boolean isConcurrent() {

--- a/src/main/java/com/tagtraum/perf/gcviewer/model/AbstractGCEvent.java
+++ b/src/main/java/com/tagtraum/perf/gcviewer/model/AbstractGCEvent.java
@@ -46,7 +46,7 @@ public abstract class AbstractGCEvent<T extends AbstractGCEvent<T>> implements S
     public void add(T detail) {
         // most events have only one detail event
         if (details == null) {
-        	details = new ArrayList<T>(2);
+            details = new ArrayList<T>(2);
         }
         details.add(detail);
         typeAsString += "; " + detail.getExtendedType().getName();
@@ -80,7 +80,7 @@ public abstract class AbstractGCEvent<T extends AbstractGCEvent<T>> implements S
 
     @Override
     protected Object clone() throws CloneNotSupportedException {
-        AbstractGCEvent<T> clonedEvent = (AbstractGCEvent<T>)super.clone();
+        AbstractGCEvent<T> clonedEvent = (AbstractGCEvent<T>) super.clone();
         if (getDatestamp() != null) {
             clonedEvent.setDateStamp(ZonedDateTime.from(this.getDatestamp()));
         }
@@ -90,7 +90,7 @@ public abstract class AbstractGCEvent<T extends AbstractGCEvent<T>> implements S
         if (details != null) {
             List<T> detailClones = new ArrayList<>();
             for (T t : details) {
-                detailClones.add((T)t.clone());
+                detailClones.add((T) t.clone());
             }
             clonedEvent.details = detailClones;
         }
@@ -102,7 +102,7 @@ public abstract class AbstractGCEvent<T extends AbstractGCEvent<T>> implements S
 
     public AbstractGCEvent<T> cloneAndMerge(AbstractGCEvent<T> otherEvent) {
         try {
-            AbstractGCEvent<T> clonedEvent = (AbstractGCEvent<T>)otherEvent.clone();
+            AbstractGCEvent<T> clonedEvent = (AbstractGCEvent<T>) otherEvent.clone();
             clonedEvent.setExtendedType(new ExtendedType(getExtendedType().getType(), getExtendedType().fullName + "+" + clonedEvent.getExtendedType().fullName));
             clonedEvent.setPreUsed(clonedEvent.getPreUsed() + getPreUsed());
             clonedEvent.setPostUsed(clonedEvent.getPostUsed() + getPostUsed());
@@ -115,7 +115,7 @@ public abstract class AbstractGCEvent<T extends AbstractGCEvent<T>> implements S
     }
 
     public void setDateStamp(ZonedDateTime datestamp) {
-    	this.datestamp = datestamp;
+        this.datestamp = datestamp;
     }
 
     public void setNumber(int number) {
@@ -158,7 +158,7 @@ public abstract class AbstractGCEvent<T extends AbstractGCEvent<T>> implements S
     }
 
     public String getTypeAsString() {
-    	return typeAsString;
+        return typeAsString;
     }
 
     public boolean isStopTheWorld() {
@@ -176,6 +176,7 @@ public abstract class AbstractGCEvent<T extends AbstractGCEvent<T>> implements S
 
     /**
      * Returns the generation of the event including generation of detail events if present.
+     *
      * @return generation of event including generation of detail events
      */
     public Generation getGeneration() {
@@ -194,7 +195,7 @@ public abstract class AbstractGCEvent<T extends AbstractGCEvent<T>> implements S
                     generation = Generation.ALL;
                 }
                 else if (generationSet.size() == 1) {
-                    generation  = generationSet.iterator().next();
+                    generation = generationSet.iterator().next();
                 }
                 else {
                     // default
@@ -247,7 +248,7 @@ public abstract class AbstractGCEvent<T extends AbstractGCEvent<T>> implements S
     public abstract void toStringBuffer(StringBuffer sb);
 
     @Override
-	public String toString() {
+    public String toString() {
         StringBuffer sb = new StringBuffer(128);
         toStringBuffer(sb);
         return sb.toString();
@@ -441,7 +442,7 @@ public abstract class AbstractGCEvent<T extends AbstractGCEvent<T>> implements S
         public String toString() {
             return fullName;
         }
-	}
+    }
 
     /**
      * Representation of an event type
@@ -460,7 +461,7 @@ public abstract class AbstractGCEvent<T extends AbstractGCEvent<T>> implements S
         }
 
         private Type(String name, Generation generation, Concurrency concurrency) {
-        	this(name, generation, concurrency, GcPattern.GC_MEMORY_PAUSE);
+            this(name, generation, concurrency, GcPattern.GC_MEMORY_PAUSE);
         }
 
         private Type(String name, Generation generation, Concurrency concurrency, GcPattern pattern) {
@@ -494,7 +495,7 @@ public abstract class AbstractGCEvent<T extends AbstractGCEvent<T>> implements S
         }
 
         public GcPattern getPattern() {
-        	return pattern;
+            return pattern;
         }
 
         public CollectionType getCollectionType() {
@@ -544,11 +545,11 @@ public abstract class AbstractGCEvent<T extends AbstractGCEvent<T>> implements S
         public static final Type CMS_PERM = new Type("CMS Perm", Generation.PERM, Concurrency.SERIAL, GcPattern.GC_MEMORY);
 
         // Parnew (promotion failed)
-         public static final Type PAR_NEW_PROMOTION_FAILED = new Type("ParNew (promotion failed)", Generation.YOUNG, Concurrency.SERIAL);
+        public static final Type PAR_NEW_PROMOTION_FAILED = new Type("ParNew (promotion failed)", Generation.YOUNG, Concurrency.SERIAL);
 
         // CMS (concurrent mode failure / interrupted)
-         public static final Type CMS_CMF = new Type("CMS (concurrent mode failure)", Generation.TENURED, Concurrency.SERIAL);
-         public static final Type CMS_CMI = new Type("CMS (concurrent mode interrupted)", Generation.TENURED, Concurrency.SERIAL);
+        public static final Type CMS_CMF = new Type("CMS (concurrent mode failure)", Generation.TENURED, Concurrency.SERIAL);
+        public static final Type CMS_CMI = new Type("CMS (concurrent mode interrupted)", Generation.TENURED, Concurrency.SERIAL);
 
         // CMS (Concurrent Mark Sweep) Event Types
         public static final Type CMS_CONCURRENT_MARK_START = new Type("CMS-concurrent-mark-start", Generation.TENURED, Concurrency.CONCURRENT, GcPattern.GC);
@@ -569,7 +570,7 @@ public abstract class AbstractGCEvent<T extends AbstractGCEvent<T>> implements S
         public static final Type ASCMS = new Type("ASCMS", Generation.TENURED);
 
         // Parnew (promotion failed) AdaptiveSizePolicy
-         public static final Type ASPAR_NEW_PROMOTION_FAILED = new Type("ASParNew (promotion failed)", Generation.YOUNG, Concurrency.SERIAL);
+        public static final Type ASPAR_NEW_PROMOTION_FAILED = new Type("ASParNew (promotion failed)", Generation.YOUNG, Concurrency.SERIAL);
 
         // CMS (concurrent mode failure / interrupted) AdaptiveSizePolicy
         public static final Type ASCMS_CMF = new Type("ASCMS (concurrent mode failure)", Generation.TENURED, Concurrency.SERIAL);
@@ -720,7 +721,7 @@ public abstract class AbstractGCEvent<T extends AbstractGCEvent<T>> implements S
         public static final Type IBM_NURSERY = new Type("nursery", Generation.YOUNG);
         public static final Type IBM_TENURE = new Type("tenure", Generation.TENURED);
 
-        public static final Type IBM_CONCURRENT_COLLECTION_START = new Type("concurrent-collection-start", Generation.ALL, Concurrency.CONCURRENT);
+        public static final Type IBM_CONCURRENT_COLLECTION_START = new Type("concurrent-collection-start global", Generation.ALL, Concurrency.CONCURRENT);
 
     }
 

--- a/src/main/java/com/tagtraum/perf/gcviewer/view/ModelChartImpl.java
+++ b/src/main/java/com/tagtraum/perf/gcviewer/view/ModelChartImpl.java
@@ -57,7 +57,7 @@ public class ModelChartImpl extends JScrollPane implements ModelChart, ChangeLis
     private UsedTenuredRenderer usedTenuredRenderer;
     private UsedYoungRenderer usedYoungRenderer;
     private InitialMarkLevelRenderer initialMarkLevelRenderer;
-    private ConcurrentGcBegionEndRenderer concurrentGcLineRenderer;
+    private ConcurrentGcBeginEndRenderer concurrentGcLineRenderer;
     private boolean antiAlias;
     private TimeOffsetPanel timeOffsetPanel;
     private int lastViewPortWidth = 0;
@@ -91,7 +91,7 @@ public class ModelChartImpl extends JScrollPane implements ModelChart, ChangeLis
         chart.add(gcRectanglesRenderer, gridBagConstraints);
         incLineRenderer = new IncLineRenderer(this);
         chart.add(incLineRenderer, gridBagConstraints);
-        concurrentGcLineRenderer = new ConcurrentGcBegionEndRenderer(this);
+        concurrentGcLineRenderer = new ConcurrentGcBeginEndRenderer(this);
         chart.add(concurrentGcLineRenderer, gridBagConstraints);
         gcTimesRenderer = new GCTimesRenderer(this);
         chart.add(gcTimesRenderer, gridBagConstraints);

--- a/src/main/java/com/tagtraum/perf/gcviewer/view/renderer/ConcurrentGcBeginEndRenderer.java
+++ b/src/main/java/com/tagtraum/perf/gcviewer/view/renderer/ConcurrentGcBeginEndRenderer.java
@@ -17,11 +17,11 @@ import com.tagtraum.perf.gcviewer.view.ModelChartImpl;
  * @author <a href="mailto:jwu@gmx.ch">Joerg Wuethrich</a>
  * <p>created on: 30.10.2011</p>
  */
-public class ConcurrentGcBegionEndRenderer extends ChartRenderer {
+public class ConcurrentGcBeginEndRenderer extends ChartRenderer {
     public static final Paint CONCURRENT_COLLECTION_BEGIN = Color.CYAN;
     public static final Paint CONCURRENT_COLLECTION_END = Color.PINK;
     
-    public ConcurrentGcBegionEndRenderer(ModelChartImpl modelChart) {
+    public ConcurrentGcBeginEndRenderer(ModelChartImpl modelChart) {
         super(modelChart);
         setLinePaint(CONCURRENT_COLLECTION_BEGIN);
     }

--- a/src/test/java/com/tagtraum/perf/gcviewer/imp/TestDataReaderIBM_J9_R27.java
+++ b/src/test/java/com/tagtraum/perf/gcviewer/imp/TestDataReaderIBM_J9_R27.java
@@ -1,7 +1,9 @@
 package com.tagtraum.perf.gcviewer.imp;
 
 import static com.tagtraum.perf.gcviewer.UnittestHelper.toKiloBytes;
+import static com.tagtraum.perf.gcviewer.imp.TestDataReaderIBM_J9_R28.*;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.startsWith;
 import static org.hamcrest.number.IsCloseTo.closeTo;
 import static org.junit.Assert.assertThat;
 
@@ -22,6 +24,8 @@ import org.junit.Test;
  *         <p>created on 08.10.2014</p>
  */
 public class TestDataReaderIBM_J9_R27 {
+
+    public static final String EXPECTED_ERROR_MESSAGE = "line 233: javax.xml.stream.XMLStreamException: ParseError at [row,col]:[234,1]";
 
     private InputStream getInputStream(String fileName) throws IOException {
         return UnittestHelper.getResourceAsStream(FOLDER.IBM, fileName);
@@ -58,11 +62,13 @@ public class TestDataReaderIBM_J9_R27 {
         assertThat("tenured before", event.getTenured().getPreUsed(), is(toKiloBytes(805306368 - 804158480)));
         assertThat("tenured after", event.getTenured().getPostUsed(), is(toKiloBytes(805306368 - 804158480)));
 
-        assertThat("timestamp 1", event.getTimestamp(), closeTo(0.0, 0.0001));
-        assertThat("timestamp 2", model.get(1).getTimestamp(), closeTo(1.927, 0.0001));
-        assertThat("timestamp 3", model.get(2).getTimestamp(), closeTo(3.982, 0.0001));
+        verifyTimestamp("timestamp 1", event.getTimestamp(), "2014-09-24T15:57:32.116");
+        verifyTimestamp("timestamp 2", model.get(1).getTimestamp(), "2014-09-24T15:57:34.043");
+        verifyTimestamp("timestamp 3", model.get(2).getTimestamp(), "2014-09-24T15:57:36.098");
 
         assertThat("number of errors", handler.getCount(), is(1));
+        String message = handler.getLogRecords().get(0).getMessage();
+        assertThat("missing close tag </verbosegc>", message, startsWith(EXPECTED_ERROR_MESSAGE));
     }
 
     @Test

--- a/src/test/java/com/tagtraum/perf/gcviewer/imp/TestDataReaderIBM_J9_R27.java
+++ b/src/test/java/com/tagtraum/perf/gcviewer/imp/TestDataReaderIBM_J9_R27.java
@@ -1,7 +1,7 @@
 package com.tagtraum.perf.gcviewer.imp;
 
 import static com.tagtraum.perf.gcviewer.UnittestHelper.toKiloBytes;
-import static com.tagtraum.perf.gcviewer.imp.TestDataReaderIBM_J9_R28.*;
+import static com.tagtraum.perf.gcviewer.imp.TestDataReaderIBM_J9_R28.verifyTimestamp;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.startsWith;
 import static org.hamcrest.number.IsCloseTo.closeTo;

--- a/src/test/java/com/tagtraum/perf/gcviewer/imp/TestDataReaderIBM_J9_R28.java
+++ b/src/test/java/com/tagtraum/perf/gcviewer/imp/TestDataReaderIBM_J9_R28.java
@@ -8,6 +8,9 @@ import static org.junit.Assert.assertThat;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.logging.Level;
 
 import com.tagtraum.perf.gcviewer.UnittestHelper;
@@ -56,12 +59,16 @@ public class TestDataReaderIBM_J9_R28 {
         assertThat("tenured before", event.getTenured().getPreUsed(), is(toKiloBytes(402653184 - 401882552)));
         assertThat("tenured after", event.getTenured().getPostUsed(), is(toKiloBytes(402653184 - 401882552)));
 
-        assertThat("timestamp 1", event.getTimestamp(), closeTo(0.0, 0.0001));
-        assertThat("timestamp 2", model.get(1).getTimestamp(), closeTo(1.272, 0.0001));
 
         assertThat("type", event.getTypeAsString(), equalTo("af scavenge; nursery"));
         assertThat("generation", event.getExtendedType().getGeneration(), is(AbstractGCEvent.Generation.YOUNG));
         assertThat("full", event.isFull(), is(false));
+        assertThat("full", event.isInc(), is(true));
+
+        verifyTimestamp("first pause timestamp", model.getFirstPauseTimeStamp(), "2015-12-31T15:22:46.957");
+        verifyTimestamp("event timestamp", event.getTimestamp(), "2015-12-31T15:22:46.957");
+        verifyTimestamp("event timestamp 2", model.get(1).getTimestamp(), "2015-12-31T15:22:48.229");
+
         assertThat("number of errors", handler.getCount(), is(0));
     }
 
@@ -81,6 +88,9 @@ public class TestDataReaderIBM_J9_R28 {
         assertThat("pause", event.getPause(), closeTo(1.255648, 0.0000001));
         assertThat("type", event.getTypeAsString(), equalTo("af global; tenure"));
 
+        verifyTimestamp("event timestamp", event.getTimestamp(), "2016-08-09T14:58:58.343");
+        verifyTimestamp("first pause timestamp", model.getFirstPauseTimeStamp(), "2016-08-09T14:58:58.343");
+
         assertThat("number of errors", handler.getCount(), is(0));
     }
 
@@ -99,6 +109,9 @@ public class TestDataReaderIBM_J9_R28 {
         GCEvent event = (GCEvent) model.get(0);
         assertThat("pause", event.getPause(), closeTo(0.097756, 0.0000001));
         assertThat("type", event.getTypeAsString(), equalTo("sys explicit global; nursery; tenure"));
+
+        verifyTimestamp("event timestamp", event.getTimestamp(), "2015-12-31T15:23:00.646");
+        verifyTimestamp("first pause timestamp", model.getFirstPauseTimeStamp(), "2015-12-31T15:23:00.646");
 
         assertThat("number of errors", handler.getCount(), is(0));
     }
@@ -131,10 +144,22 @@ public class TestDataReaderIBM_J9_R28 {
         AbstractGCEvent<?> event = model.get(0);
         assertThat("model size", model.size(), is(1));
         assertThat("duration", event.getPause(), closeTo(1.182375, 0.00000001));
-        assertThat("number of errors", handler.getCount(), is(0));
 
-        assertThat("", event.getExtendedType().getConcurrency(), is(AbstractGCEvent.Concurrency.CONCURRENT));
-        assertThat("", event.getExtendedType().getGeneration(), is(AbstractGCEvent.Generation.ALL));
+        assertThat("concurrency", event.getExtendedType().getConcurrency(), is(AbstractGCEvent.Concurrency.CONCURRENT));
+        assertThat("generation", event.getExtendedType().getGeneration(), is(AbstractGCEvent.Generation.ALL));
+        assertThat("full", event.isFull(), is(true));
+        assertThat("full", event.isInc(), is(false));
+
+        verifyTimestamp("event timestamp", event.getTimestamp(), "2016-08-09T15:14:56.110");
+        verifyTimestamp("first pause timestamp", model.getFirstPauseTimeStamp(), "2016-08-09T15:14:56.110");
+
+        assertThat("number of errors", handler.getCount(), is(0));
     }
 
+    public static void verifyTimestamp(String reason, double actual, String dateTime) {
+        DateTimeFormatter formatter = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
+        LocalDateTime localDateTime = LocalDateTime.parse(dateTime, formatter);
+        double expected = Long.valueOf(Timestamp.valueOf(localDateTime).getTime()/1000).doubleValue();
+        assertThat(reason, actual, is(expected));
+    }
 }

--- a/src/test/java/com/tagtraum/perf/gcviewer/imp/TestDataReaderIBM_J9_R28.java
+++ b/src/test/java/com/tagtraum/perf/gcviewer/imp/TestDataReaderIBM_J9_R28.java
@@ -12,10 +12,7 @@ import java.util.logging.Level;
 
 import com.tagtraum.perf.gcviewer.UnittestHelper;
 import com.tagtraum.perf.gcviewer.UnittestHelper.FOLDER;
-import com.tagtraum.perf.gcviewer.model.GCEvent;
-import com.tagtraum.perf.gcviewer.model.GCModel;
-import com.tagtraum.perf.gcviewer.model.GCResource;
-import com.tagtraum.perf.gcviewer.model.GcResourceFile;
+import com.tagtraum.perf.gcviewer.model.*;
 import org.junit.Test;
 
 /**
@@ -62,8 +59,9 @@ public class TestDataReaderIBM_J9_R28 {
         assertThat("timestamp 1", event.getTimestamp(), closeTo(0.0, 0.0001));
         assertThat("timestamp 2", model.get(1).getTimestamp(), closeTo(1.272, 0.0001));
 
-        assertThat("type", event.getTypeAsString(), equalTo("af scavenge; nursery; tenure"));
-
+        assertThat("type", event.getTypeAsString(), equalTo("af scavenge; nursery"));
+        assertThat("generation", event.getExtendedType().getGeneration(), is(AbstractGCEvent.Generation.YOUNG));
+        assertThat("full", event.isFull(), is(false));
         assertThat("number of errors", handler.getCount(), is(0));
     }
 
@@ -130,9 +128,13 @@ public class TestDataReaderIBM_J9_R28 {
         DataReader reader = getDataReader(gcResource);
         GCModel model = reader.read();
 
+        AbstractGCEvent<?> event = model.get(0);
         assertThat("model size", model.size(), is(1));
-        assertThat("duration", model.get(0).getPause(), closeTo(1.182375, 0.00000001));
+        assertThat("duration", event.getPause(), closeTo(1.182375, 0.00000001));
         assertThat("number of errors", handler.getCount(), is(0));
+
+        assertThat("", event.getExtendedType().getConcurrency(), is(AbstractGCEvent.Concurrency.CONCURRENT));
+        assertThat("", event.getExtendedType().getGeneration(), is(AbstractGCEvent.Generation.ALL));
     }
 
 }

--- a/src/test/java/com/tagtraum/perf/gcviewer/imp/TestDataReaderIBM_J9_R28.java
+++ b/src/test/java/com/tagtraum/perf/gcviewer/imp/TestDataReaderIBM_J9_R28.java
@@ -15,7 +15,12 @@ import java.util.logging.Level;
 
 import com.tagtraum.perf.gcviewer.UnittestHelper;
 import com.tagtraum.perf.gcviewer.UnittestHelper.FOLDER;
-import com.tagtraum.perf.gcviewer.model.*;
+import com.tagtraum.perf.gcviewer.model.AbstractGCEvent;
+import com.tagtraum.perf.gcviewer.model.GCEvent;
+import com.tagtraum.perf.gcviewer.model.GCModel;
+import com.tagtraum.perf.gcviewer.model.GcResourceFile;
+import com.tagtraum.perf.gcviewer.model.GCResource;
+
 import org.junit.Test;
 
 /**

--- a/src/test/java/com/tagtraum/perf/gcviewer/imp/TestDataReaderIBM_J9_R28.java
+++ b/src/test/java/com/tagtraum/perf/gcviewer/imp/TestDataReaderIBM_J9_R28.java
@@ -16,7 +16,6 @@ import com.tagtraum.perf.gcviewer.model.GCEvent;
 import com.tagtraum.perf.gcviewer.model.GCModel;
 import com.tagtraum.perf.gcviewer.model.GCResource;
 import com.tagtraum.perf.gcviewer.model.GcResourceFile;
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -42,7 +41,7 @@ public class TestDataReaderIBM_J9_R28 {
 
         DataReader reader = getDataReader(gcResource);
         GCModel model = reader.read();
-        
+
         assertThat("model size", model.size(), is(2));
 
         GCEvent event = (GCEvent) model.get(0);
@@ -121,7 +120,7 @@ public class TestDataReaderIBM_J9_R28 {
         assertThat("number of errors", handler.getCount(), is(0));
     }
 
-    @Test @Ignore
+    @Test
     public void testConcurrentCollection() throws Exception {
         TestLogHandler handler = new TestLogHandler();
         handler.setLevel(Level.WARNING);


### PR DESCRIPTION
Scavenge collects were incorrectly marked as full gc.
Concurrent collects resulted in a parse error.
Tenured heap was displayed incorrectly due to missing timestamp.