### PR TITLE
Fix quitting on macOS

### DIFF
--- a/src/main/java/com/tagtraum/perf/gcviewer/ctrl/action/Exit.java
+++ b/src/main/java/com/tagtraum/perf/gcviewer/ctrl/action/Exit.java
@@ -39,7 +39,8 @@ public class Exit extends AbstractAction {
     }
 
     // Used by OS X adaptations
-    public void quit() {
+    public boolean quit() {
         actionPerformed(null);
+        return true;
     }
 }

--- a/src/main/java/com/tagtraum/perf/gcviewer/view/util/OSXSupport.java
+++ b/src/main/java/com/tagtraum/perf/gcviewer/view/util/OSXSupport.java
@@ -112,7 +112,7 @@ public class OSXSupport {
 
             Class<?> handlerClass = Class.forName(handlerClassName);
             if (action != null) {
-                Object aboutHandlerProxy =
+                Object handlerProxy =
                     Proxy.newProxyInstance(OSXSupport.class.getClassLoader(),
                                            new Class[]{handlerClass},
                                            new InvocationHandler() {
@@ -121,10 +121,14 @@ public class OSXSupport {
                                                    if (method.getName().equals(handlerMethodName)) {
                                                        action.actionPerformed(null);
                                                    }
+                                                   if (method.getName().equals("handleQuitRequestWith")) {
+                                                       Object quitResponse = args[1];
+                                                       Class.forName("com.apple.eawt.QuitResponse").getDeclaredMethod("performQuit").invoke(quitResponse);
+                                                   }
                                                    return null;
                                                }
                                            });
-                application.getClass().getMethod(handlerSetterMethodName, handlerClass).invoke(application, aboutHandlerProxy);
+                application.getClass().getMethod(handlerSetterMethodName, handlerClass).invoke(application, handlerProxy);
             } else {
                 application.getClass().getMethod(handlerSetterMethodName, handlerClass).invoke(application, (Object) null);
             }


### PR DESCRIPTION
The `QuitHandler` that proxies our `Exit` action needs to call the `performQuit()` method on the `QuitResponse` that it receives.
See the Javadoc for `com.apple.eawt.QuitHandler.handleQuitRequestWith()` which says:
```
  /**
   * Invoked when the application is asked to quit.
   *
   * Implementors must call either {@link QuitResponse#cancelQuit()}, {@link QuitResponse#performQuit()}, or ensure the application terminates.
   * The process (or log-out) requesting this app to quit will be blocked until the {@link QuitResponse} is handled.
   ...
```

Fixes #247