### PR TITLE
Tuned data panel tabs content alignment to have more consistent UI

### DIFF
--- a/src/main/java/com/tagtraum/perf/gcviewer/view/GCDocument.java
+++ b/src/main/java/com/tagtraum/perf/gcviewer/view/GCDocument.java
@@ -192,7 +192,7 @@ public class GCDocument extends JInternalFrame {
             constraints.gridx = 1;
             constraints.weightx = 0;
             constraints.weighty = 0;
-            constraints.fill = GridBagConstraints.HORIZONTAL;
+            constraints.fill = GridBagConstraints.BOTH;
             constraints.anchor = GridBagConstraints.SOUTH;
             getContentPane().add(modelMetricsPanel, constraints);
             modelMetricsPanel.setVisible(showModelMetricsPanel && (!chartPanelView.isMinimized()));

--- a/src/main/java/com/tagtraum/perf/gcviewer/view/ModelMetricsPanel.java
+++ b/src/main/java/com/tagtraum/perf/gcviewer/view/ModelMetricsPanel.java
@@ -179,7 +179,13 @@ public class ModelMetricsPanel extends JTabbedPane {
             
             labelMap.put(name, new TwoLabelsContainer(nameLabel, valueLabel));
     	}
-    	
+
+    	public void fixGroupsHeight() {
+    	    for (Component component : getComponents()) {
+    	        component.setMaximumSize(new Dimension(component.getMaximumSize().width, component.getPreferredSize().height));
+            }
+        }
+
     	public void removeEntry(String name) {
     	    TwoLabelsContainer labelContainer = labelMap.get(name);
     	    assert labelContainer != null : "labelContainer for '" + name + "' is null -> was it registered?";
@@ -233,8 +239,10 @@ public class ModelMetricsPanel extends JTabbedPane {
             
             addEntry(LocalisationHelper.getString("data_panel_memory_promotion_avg"));
             addEntry(LocalisationHelper.getString("data_panel_memory_promotion_total"));
-       }
-        
+
+            fixGroupsHeight();
+        }
+
         public void setModel(GCModel model) {
             boolean fullGcDataAvailable = model.getFootprintAfterFullGC().getN() != 0;
             boolean fullGcSlopeDataAvailable = model.getFootprintAfterFullGC().getN() > 1;
@@ -377,8 +385,10 @@ public class ModelMetricsPanel extends JTabbedPane {
             addEntry(LocalisationHelper.getString("data_panel_count_gc_pauses"));
             addEntry(LocalisationHelper.getString("data_panel_avg_gcpause"));
             addEntry(LocalisationHelper.getString("data_panel_min_max_gc_pause"));
+
+            fixGroupsHeight();
         }
-        
+
         public void setModel(GCModel model) {
             boolean pauseDataAvailable = model.getPause().getN() > 0;
             boolean gcDataAvailable = model.getGCPause().getN() > 0;
@@ -469,8 +479,10 @@ public class ModelMetricsPanel extends JTabbedPane {
             addEntry(LocalisationHelper.getString("data_panel_performance_fullgc"));
             addEntry(LocalisationHelper.getString("data_panel_count_gc_pauses"));
             addEntry(LocalisationHelper.getString("data_panel_performance_gc"));
+
+            fixGroupsHeight();
         }
-        
+
         public void setModel(GCModel model) {
             boolean fullGcDataAvailable = model.getFootprintAfterFullGC().getN() > 0;
             boolean postConcurrentUsedSizeAvailable = model.getPostConcurrentCycleHeapUsedSizes().getN() > 0;


### PR DESCRIPTION
I've made a small tunings for UI:
* tabs are on the same level for chart and data panels
* margins between labels on data panel are now the same on chart and data panels

Before:
<img width="1452" alt="before" src="https://user-images.githubusercontent.com/726941/104011479-384b6280-51bf-11eb-86dc-2f32e55ccab4.png">

After:
<img width="1452" alt="after" src="https://user-images.githubusercontent.com/726941/104011487-3a152600-51bf-11eb-8b02-a3571c55eba4.png">
