### PR TITLE
Support to parse PrintGCID

### DIFF
--- a/src/main/java/com/tagtraum/perf/gcviewer/imp/AbstractDataReaderSun.java
+++ b/src/main/java/com/tagtraum/perf/gcviewer/imp/AbstractDataReaderSun.java
@@ -301,6 +301,33 @@ public abstract class AbstractDataReaderSun extends AbstractDataReader {
         }
     }
 
+    protected void parseId(String line, ParseInformation pos) throws ParseException {
+        if (!line.contains("#"))
+            return;
+        int i = pos.getIndex();
+        try {
+            // consume all leading spaces and #
+            final int lineLength = line.length();
+            final char[] lineChars = line.toCharArray();
+            char c = lineChars[i];
+            for (; i < lineLength; c = lineChars[++i]) {
+                if (c != ' ' && c != '#') break;
+            }
+            if (i >= lineLength)
+                throw new ParseException("Unexpected end of line.", line);
+            // check whether the type name starts with a number
+            // -> skip number
+            for (; Character.isDigit(c) && i < lineLength; c = lineChars[++i]);
+            // -> skip :
+            for (; i<lineLength; c = lineChars[++i]) {
+                if (c != ':') break;
+            }
+        }
+        finally {
+            pos.setIndex(i);
+        }
+    }
+
     protected ExtendedType parseType(String line, ParseInformation pos) throws ParseException {
         String typeString = parseTypeString(line, pos);
         return getDataReaderTools().parseType(typeString);

--- a/src/main/java/com/tagtraum/perf/gcviewer/imp/AbstractDataReaderSun.java
+++ b/src/main/java/com/tagtraum/perf/gcviewer/imp/AbstractDataReaderSun.java
@@ -301,7 +301,8 @@ public abstract class AbstractDataReaderSun extends AbstractDataReader {
         }
     }
 
-    protected void parseId(String line, ParseInformation pos) throws ParseException {
+    // restriction PringGCID only for parallel scavenge collector
+    protected void parseGcId(String line, ParseInformation pos) throws ParseException {
         if (!line.contains("#"))
             return;
         int i = pos.getIndex();

--- a/src/main/java/com/tagtraum/perf/gcviewer/imp/AbstractDataReaderSun.java
+++ b/src/main/java/com/tagtraum/perf/gcviewer/imp/AbstractDataReaderSun.java
@@ -306,21 +306,23 @@ public abstract class AbstractDataReaderSun extends AbstractDataReader {
             return;
         int i = pos.getIndex();
         try {
-            // consume all leading spaces and #
+            // consume all leading spaces and '#'
             final int lineLength = line.length();
             final char[] lineChars = line.toCharArray();
             char c = lineChars[i];
             for (; i < lineLength; c = lineChars[++i]) {
-                if (c != ' ' && c != '#') break;
+                if (c != ' ' && c != '#')
+                    break;
             }
             if (i >= lineLength)
                 throw new ParseException("Unexpected end of line.", line);
-            // check whether the type name starts with a number
+            // check whether the Id starts with a number
             // -> skip number
             for (; Character.isDigit(c) && i < lineLength; c = lineChars[++i]);
-            // -> skip :
+            // -> skip ':'
             for (; i<lineLength; c = lineChars[++i]) {
-                if (c != ':') break;
+                if (c != ':')
+                    break;
             }
         }
         finally {

--- a/src/main/java/com/tagtraum/perf/gcviewer/imp/AbstractDataReaderSun.java
+++ b/src/main/java/com/tagtraum/perf/gcviewer/imp/AbstractDataReaderSun.java
@@ -326,6 +326,7 @@ public abstract class AbstractDataReaderSun extends AbstractDataReader {
             }
         }
         finally {
+            i++;
             pos.setIndex(i);
         }
     }

--- a/src/main/java/com/tagtraum/perf/gcviewer/imp/DataReaderSun1_6_0.java
+++ b/src/main/java/com/tagtraum/perf/gcviewer/imp/DataReaderSun1_6_0.java
@@ -620,6 +620,7 @@ public class DataReaderSun1_6_0 extends AbstractDataReaderSun {
             // pre-used->post-used, total, time
             ZonedDateTime datestamp = parseDatestamp(line, pos);
             double timestamp = getTimestamp(line, pos, datestamp);
+            parseId(line, pos);
             ExtendedType type = parseType(line, pos);
             AbstractGCEvent<?> ae;
             if (type.getConcurrency() == Concurrency.CONCURRENT) {

--- a/src/main/java/com/tagtraum/perf/gcviewer/imp/DataReaderSun1_6_0.java
+++ b/src/main/java/com/tagtraum/perf/gcviewer/imp/DataReaderSun1_6_0.java
@@ -620,8 +620,7 @@ public class DataReaderSun1_6_0 extends AbstractDataReaderSun {
             // pre-used->post-used, total, time
             ZonedDateTime datestamp = parseDatestamp(line, pos);
             double timestamp = getTimestamp(line, pos, datestamp);
-            // Support for PrintGCID
-            parseId(line, pos);
+            parseGcId(line, pos);
             ExtendedType type = parseType(line, pos);
             AbstractGCEvent<?> ae;
             if (type.getConcurrency() == Concurrency.CONCURRENT) {

--- a/src/main/java/com/tagtraum/perf/gcviewer/imp/DataReaderSun1_6_0.java
+++ b/src/main/java/com/tagtraum/perf/gcviewer/imp/DataReaderSun1_6_0.java
@@ -620,6 +620,7 @@ public class DataReaderSun1_6_0 extends AbstractDataReaderSun {
             // pre-used->post-used, total, time
             ZonedDateTime datestamp = parseDatestamp(line, pos);
             double timestamp = getTimestamp(line, pos, datestamp);
+            // Support for PrintGCID
             parseId(line, pos);
             ExtendedType type = parseType(line, pos);
             AbstractGCEvent<?> ae;

--- a/src/main/java/com/tagtraum/perf/gcviewer/imp/DataReaderSun1_6_0G1.java
+++ b/src/main/java/com/tagtraum/perf/gcviewer/imp/DataReaderSun1_6_0G1.java
@@ -551,6 +551,7 @@ public class DataReaderSun1_6_0G1 extends AbstractDataReaderSun {
             // pre-used->post-used, total, time
             ZonedDateTime datestamp = parseDatestamp(line, pos);
             double timestamp = getTimestamp(line, pos, datestamp);
+            parseId(line, pos);
             ExtendedType type = parseType(line, pos);
             // special provision for concurrent events
             if (type.getConcurrency() == Concurrency.CONCURRENT) {

--- a/src/main/java/com/tagtraum/perf/gcviewer/imp/DataReaderSun1_6_0G1.java
+++ b/src/main/java/com/tagtraum/perf/gcviewer/imp/DataReaderSun1_6_0G1.java
@@ -551,8 +551,7 @@ public class DataReaderSun1_6_0G1 extends AbstractDataReaderSun {
             // pre-used->post-used, total, time
             ZonedDateTime datestamp = parseDatestamp(line, pos);
             double timestamp = getTimestamp(line, pos, datestamp);
-            // Support for PrintGCID
-            parseId(line, pos);
+            parseGcId(line, pos);
             ExtendedType type = parseType(line, pos);
             // special provision for concurrent events
             if (type.getConcurrency() == Concurrency.CONCURRENT) {
@@ -580,11 +579,7 @@ public class DataReaderSun1_6_0G1 extends AbstractDataReaderSun {
                     parseDetailEventsIfExist(line, pos, event);
 
                 if (event.getExtendedType().getPattern() == GcPattern.GC_MEMORY_PAUSE) {
-                    // Support for PrintGCID
-                    if (line.contains("#"))
-                        event.setPause(parsePause(line, pos));
-                    else
-                        setMemoryAndPauses(event, line, pos);
+                    setMemoryAndPauses(event, line, pos);
                 } else {
                     event.setPause(parsePause(line, pos));
                 }

--- a/src/main/java/com/tagtraum/perf/gcviewer/imp/DataReaderSun1_6_0G1.java
+++ b/src/main/java/com/tagtraum/perf/gcviewer/imp/DataReaderSun1_6_0G1.java
@@ -551,6 +551,7 @@ public class DataReaderSun1_6_0G1 extends AbstractDataReaderSun {
             // pre-used->post-used, total, time
             ZonedDateTime datestamp = parseDatestamp(line, pos);
             double timestamp = getTimestamp(line, pos, datestamp);
+            // Support for PrintGCID
             parseId(line, pos);
             ExtendedType type = parseType(line, pos);
             // special provision for concurrent events
@@ -579,10 +580,12 @@ public class DataReaderSun1_6_0G1 extends AbstractDataReaderSun {
                     parseDetailEventsIfExist(line, pos, event);
 
                 if (event.getExtendedType().getPattern() == GcPattern.GC_MEMORY_PAUSE) {
-                    if (!line.contains("#"))
+                    // Support for PrintGCID
+                    if (line.contains("#"))
+                        event.setPause(parsePause(line, pos));
+                    else
                         setMemoryAndPauses(event, line, pos);
-                }
-                else {
+                } else {
                     event.setPause(parsePause(line, pos));
                 }
             }

--- a/src/main/java/com/tagtraum/perf/gcviewer/imp/DataReaderSun1_6_0G1.java
+++ b/src/main/java/com/tagtraum/perf/gcviewer/imp/DataReaderSun1_6_0G1.java
@@ -579,7 +579,8 @@ public class DataReaderSun1_6_0G1 extends AbstractDataReaderSun {
                     parseDetailEventsIfExist(line, pos, event);
 
                 if (event.getExtendedType().getPattern() == GcPattern.GC_MEMORY_PAUSE) {
-                    setMemoryAndPauses(event, line, pos);
+                    if (!line.contains("#"))
+                        setMemoryAndPauses(event, line, pos);
                 }
                 else {
                     event.setPause(parsePause(line, pos));

--- a/src/main/java/com/tagtraum/perf/gcviewer/model/AbstractGCEvent.java
+++ b/src/main/java/com/tagtraum/perf/gcviewer/model/AbstractGCEvent.java
@@ -662,6 +662,7 @@ public abstract class AbstractGCEvent<T extends AbstractGCEvent<T>> implements S
         public static final Type UJL_CMS_CONCURRENT_OLD = new Type("Old", Generation.TENURED, Concurrency.CONCURRENT, GcPattern.GC_MEMORY);
 
         // unified jvm logging g1 event types
+        public static final Type UJL_G1_PAUSE_YOUNG = new Type("pause (G1 Evacuation Pause) (young)", Generation.YOUNG, Concurrency.SERIAL, GcPattern.GC_PAUSE);
         public static final Type UJL_G1_PAUSE_MIXED = new Type("Pause Mixed", Generation.TENURED, Concurrency.SERIAL, GcPattern.GC_MEMORY_PAUSE);
         public static final Type UJL_G1_TO_SPACE_EXHAUSTED = new Type("To-space exhausted", Generation.YOUNG, Concurrency.SERIAL, GcPattern.GC);
         public static final Type UJL_G1_CONCURRENT_CYCLE = new Type("Concurrent Cycle", Generation.TENURED, Concurrency.CONCURRENT, GcPattern.GC_PAUSE);

--- a/src/main/java/com/tagtraum/perf/gcviewer/model/AbstractGCEvent.java
+++ b/src/main/java/com/tagtraum/perf/gcviewer/model/AbstractGCEvent.java
@@ -662,7 +662,6 @@ public abstract class AbstractGCEvent<T extends AbstractGCEvent<T>> implements S
         public static final Type UJL_CMS_CONCURRENT_OLD = new Type("Old", Generation.TENURED, Concurrency.CONCURRENT, GcPattern.GC_MEMORY);
 
         // unified jvm logging g1 event types
-        public static final Type UJL_G1_PAUSE_YOUNG = new Type("pause (G1 Evacuation Pause) (young)", Generation.YOUNG, Concurrency.SERIAL, GcPattern.GC_PAUSE);
         public static final Type UJL_G1_PAUSE_MIXED = new Type("Pause Mixed", Generation.TENURED, Concurrency.SERIAL, GcPattern.GC_MEMORY_PAUSE);
         public static final Type UJL_G1_TO_SPACE_EXHAUSTED = new Type("To-space exhausted", Generation.YOUNG, Concurrency.SERIAL, GcPattern.GC);
         public static final Type UJL_G1_CONCURRENT_CYCLE = new Type("Concurrent Cycle", Generation.TENURED, Concurrency.CONCURRENT, GcPattern.GC_PAUSE);

--- a/src/test/java/com/tagtraum/perf/gcviewer/imp/TestDataReaderSun1_8_0.java
+++ b/src/test/java/com/tagtraum/perf/gcviewer/imp/TestDataReaderSun1_8_0.java
@@ -417,4 +417,19 @@ public class TestDataReaderSun1_8_0 {
                 is(1L));
     }
 
+    @Test
+    public void parallelPrintGCID() throws Exception {
+        TestLogHandler handler = new TestLogHandler();
+        handler.setLevel(Level.WARNING);
+        GCResource gcResource = new GcResourceFile("SampleSun1_8_0ParallelPrintGCID.txt");
+        gcResource.getLogger().addHandler(handler);
+        
+        DataReader reader = getDataReader(gcResource);
+        GCModel model = reader.read();
+
+        assertThat("gc count", model.size(), is(5));
+
+        assertEquals("number of errors", 0, handler.getCount());
+    }
+
 }

--- a/src/test/resources/openjdk/SampleSun1_8_0ParallelPrintGCID.txt
+++ b/src/test/resources/openjdk/SampleSun1_8_0ParallelPrintGCID.txt
@@ -1,0 +1,17 @@
+OpenJDK 64-Bit Server VM (25.71-b00) for linux-loongarch64 JRE (1.8.0-internal-loongson_2022_07_26_20_28-b00), built on Jul 26 2022 20:34:57 by "loongson" with gcc 8.3.0
+Memory: 16k page, physical 16539232k(15517424k free), swap 9227440k(9227440k free)
+CommandLine flags: -XX:InitialHeapSize=10737418240 -XX:MaxHeapSize=10737418240 -XX:MaxNewSize=9663676416 -XX:NewSize=9663676416 -XX:+PrintGC -XX:+PrintGCDateStamps -XX:+PrintGCDetails -XX:+PrintGCID -XX:+PrintGCTimeStamps -XX:+UseCompressedClassPointers -XX:+UseCompressedOops -XX:+UseParallelGC 
+2022-07-26T21:00:40.750+0800: 3.117: #0: [GC (Allocation Failure) [PSYoungGen: 7077888K->222570K(8257536K)] 7077888K->222586K(9306112K), 0.5437135 secs] [Times: user=1.92 sys=0.20, real=0.55 secs] 
+2022-07-26T21:00:45.037+0800: 7.405: #1: [GC (System.gc()) [PSYoungGen: 3729513K->98289K(8257536K)] 3729529K->98321K(9306112K), 0.1937274 secs] [Times: user=0.69 sys=0.07, real=0.19 secs] 
+2022-07-26T21:00:45.231+0800: 7.599: #2: [Full GC (System.gc()) [PSYoungGen: 98289K->0K(8257536K)] [ParOldGen: 32K->98112K(1048576K)] 98321K->98112K(9306112K), [Metaspace: 16471K->16471K(1064960K)], 0.6492397 secs] [Times: user=1.52 sys=0.17, real=0.65 secs] 
+2022-07-26T21:02:14.912+0800: 97.280: #3: [GC (System.gc()) [PSYoungGen: 6687404K->105989K(8257536K)] 6785517K->204182K(9306112K), 0.0216159 secs] [Times: user=0.06 sys=0.00, real=0.03 secs] 
+2022-07-26T21:02:14.934+0800: 97.301: #4: [Full GC (System.gc()) [PSYoungGen: 105989K->0K(8257536K)] [ParOldGen: 98192K->203813K(1048576K)] 204182K->203813K(9306112K), [Metaspace: 19966K->19962K(1067008K)], 0.4555626 secs] [Times: user=1.52 sys=0.13, real=0.45 secs] 
+Heap
+ PSYoungGen      total 8086016K, used 7277906K [0x0000000580000000, 0x00000007c0000000, 0x00000007c0000000)
+  eden space 7013376K, 88% used [0x0000000580000000,0x00000006fabd8888,0x000000072c100000)
+  from space 1072640K, 99% used [0x000000077e880000,0x00000007bfffc138,0x00000007c0000000)
+  to   space 1211904K, 0% used [0x000000072c100000,0x000000072c100000,0x0000000776080000)
+ ParOldGen       total 1048576K, used 370122K [0x0000000540000000, 0x0000000580000000, 0x0000000580000000)
+  object space 1048576K, 35% used [0x0000000540000000,0x00000005569728e0,0x0000000580000000)
+ Metaspace       used 29044K, capacity 29852K, committed 29952K, reserved 1075200K
+  class space    used 3288K, capacity 3510K, committed 3584K, reserved 1048576K


### PR DESCRIPTION
Hi,

Fixed https://github.com/chewiebug/GCViewer/issues/197

Testcase:

Command Line:

```
-Xloggc:specjbb2015-psgc-`date +%Y%m%d%H%M%S`.log -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+PrintGCTimeStamps -XX:+PrintGCID
```

GC log:

```
2022-07-26T23:30:28.892+0800: 8991.259: #353: [Full GC (System.gc()) [PSYoungGen: 384K->0K(7465472K)] [ParOldGen: 325752K->325474K(1048576K)] 326136K->325474K(8514048K), [Metaspace: 20971K->20971K(1069056K)], 0.4225592 secs] [Times: user=1.49 sys=0.01, real=0.43 secs]
```

Please review my patch.

Thanks,
Leslie Zhai