### PR TITLE
Fix the issue: When the windowY value exceeds the monitor height, set it to zero by default to ensure visibility.

### DIFF
--- a/src/main/java/com/tagtraum/perf/gcviewer/ctrl/impl/GCViewerGuiController.java
+++ b/src/main/java/com/tagtraum/perf/gcviewer/ctrl/impl/GCViewerGuiController.java
@@ -38,8 +38,13 @@ public class GCViewerGuiController extends WindowAdapter {
                 // TODO necessary? state is set above; no GCDocument open at this moment
                 //viewMenuActionListener.actionPerformed(new ActionEvent(item, 0, item.getActionCommand()));
             }
+
+            int windowY = preferences.getWindowY();
+            int windowHeight = preferences.getWindowHeight();
+             windowY = windowY > windowHeight? 0 :windowY;
+
             gui.setBounds(preferences.getWindowX(),
-                    preferences.getWindowY(),
+                    windowY,
                     preferences.getWindowWidth(),
                     preferences.getWindowHeight());
             String lastfile = preferences.getLastFile();
@@ -85,10 +90,16 @@ public class GCViewerGuiController extends WindowAdapter {
             JCheckBoxMenuItem item = menuEntry.getValue();
             preferences.setGcLineProperty(item.getActionCommand(), item.getState());
         }
+
+
+        int windowY = preferences.getWindowY();
+        int windowHeight = preferences.getWindowHeight();
+        windowY = windowY > windowHeight? 0 :windowY;
+
         preferences.setWindowWidth(gui.getWidth());
         preferences.setWindowHeight(gui.getHeight());
         preferences.setWindowX(gui.getX());
-        preferences.setWindowY(gui.getY());
+        preferences.setWindowY(windowY);
         OpenFile openFileAction = (OpenFile)gui.getActionMap().get(ActionCommands.OPEN_FILE.toString());
         if (openFileAction.getLastSelectedFiles().length != 0) {
             preferences.setLastFile(openFileAction.getLastSelectedFiles()[0].getAbsolutePath());


### PR DESCRIPTION
I have two monitors: one is an LG monitor with a resolution of 3840 x 2160, and the other is a Xiaomi monitor with a resolution of 1920 x 1080.

I encountered an issue while using an Active Directory domain account.

While using an Administrator account on a non-Active Directory (AD) domain on the same PC, it works correctly.

When I first launched the app on my LG monitor, the GCViewerGui was obscured. The only action available to me was to click the close button in the taskbar. After numerous attempts and extensive debugging, I encountered an unusual windowY value of 4957 and a windowX value of -11.

I cannot repeat this issue: which moment the
`java

System.getProperty("user.home") + "/gcviewer.properties"

`
was generated, and why i got the windowY value of 4957 and the windowX value of -11.

this solution works for me:

before
`java

    void applyPreferences(GCViewerGui gui, GCPreferences preferences) {
            ...
            gui.setBounds(preferences.getWindowX(),
                    preferences.getWindowY(),
                    preferences.getWindowWidth(),
                    preferences.getWindowHeight());
           ...
    }

    private GCPreferences copyPreferencesFromGui(GCViewerGui gui) {
       ...
        preferences.setWindowWidth(gui.getWidth());
        preferences.setWindowHeight(gui.getHeight());
        preferences.setWindowX(gui.getX());
        preferences.setWindowY(preferences.getWindowY());
        ...
    }
`

com.tagtraum.perf.gcviewer.view.GCViewerGui[
    frame0,
    4597,
    -11,
    2326x1258,
    layout=java.awt.BorderLayout,
    title=tagtraum industries incorporated - GCViewer,
    resizable,
    normal,
    defaultCloseOperation=DO_NOTHING_ON_CLOSE,
    rootPane=javax.swing.JRootPane[
        ,11,45,2304x1202,
        layout=javax.swing.JRootPane$RootLayout,
        alignmentX=0.0,
        alignmentY=0.0,
        border=,
        flags=16777673,
        maximumSize=,
        minimumSize=,
        preferredSize=
    ],
    rootPaneCheckingEnabled=true
]

![image](https://github.com/user-attachments/assets/599ff753-6cf9-476b-8c59-9cb22b0dee6c)

![image](https://github.com/user-attachments/assets/7f8b2f1c-3b91-4e54-bd79-76a6fc01762d)

gcviewer.properties
`java

view.showdatestamp=true
view.gctimesline=true
view.incgclines=true
view.totalmemory=true
lastfile=F\:\\dump\\java\\task-service-messervicetest-gc-2025-02-20_17-03-26.log
view.usedyoungmemory=true
view.gctimesrectangles=true
view.usedtenuredmemory=true
view.youngmemory=true
window.width=3862
view.concurrentcollectionbeginend=true
view.tenuredmemory=true
view.initialmarklevel=true
window.height=2060
view.fullgclines=true
window.y=4957
window.x=-11
view.antialias=true
view.usedmemory=true
`


after
`java

       void applyPreferences(GCViewerGui gui, GCPreferences preferences) {
            ...
            int windowY = preferences.getWindowY();
            int windowHeight = preferences.getWindowHeight();
             windowY = windowY > windowHeight? 0 :windowY;

            gui.setBounds(preferences.getWindowX(),
                    windowY,
                    preferences.getWindowWidth(),
                    preferences.getWindowHeight());
           ...
    }


  private GCPreferences copyPreferencesFromGui(GCViewerGui gui) {
       ...


        int windowY = preferences.getWindowY();
        int windowHeight = preferences.getWindowHeight();
        windowY = windowY > windowHeight? 0 :windowY;

        preferences.setWindowWidth(gui.getWidth());
        preferences.setWindowHeight(gui.getHeight());
        preferences.setWindowX(gui.getX());
        preferences.setWindowY(windowY);
        ...
    }
`


com.tagtraum.perf.gcviewer.view.GCViewerGui[
    frame0,
    0,
    0,
    0x0,
    invalid,
    hidden,
    layout=java.awt.BorderLayout,
    title=tagtraum industries incorporated - GCViewer,
    resizable,
    normal,
    defaultCloseOperation=DO_NOTHING_ON_CLOSE,
    rootPane=javax.swing.JRootPane[
        ,
        0,
        0,
        0x0,
        invalid,
        layout=javax.swing.JRootPane$RootLayout,
        alignmentX=0.0,
        alignmentY=0.0,
        border=,
        flags=16777673,
        maximumSize=,
        minimumSize=,
        preferredSize=
    ],
    rootPaneCheckingEnabled=true
]
