### PR TITLE
fix(getDataWriter): close FileOutputStream in getD

### DIFF
--- a/src/main/java/com/tagtraum/perf/gcviewer/exp/impl/DataWriterFactory.java
+++ b/src/main/java/com/tagtraum/perf/gcviewer/exp/impl/DataWriterFactory.java
@@ -47,15 +47,16 @@ public class DataWriterFactory {
      * @throws IOException unknown DataWriter or problem creating file
      */
     public static DataWriter getDataWriter(File file, DataWriterType type, Map<String, Object> configuration) throws IOException {
-        FileOutputStream outputStream = new FileOutputStream(file);
-        switch (type) {
-            case PLAIN   : return new PlainDataWriter(outputStream);
-            case CSV     : return new CSVDataWriter(outputStream);
-            case CSV_TS  : return new CSVTSDataWriter(outputStream);
-            case SIMPLE  : return new SimpleGcWriter(outputStream);
-            case SUMMARY : return new SummaryDataWriter(outputStream, configuration);
-            case PNG     : return new PNGDataWriter(outputStream, configuration);
-            default : throw new IOException(LocalisationHelper.getString("datawriterfactory_instantiation_failed") + " " + file);
+        try (FileOutputStream outputStream = new FileOutputStream(file)) {
+            switch (type) {
+                case PLAIN   : return new PlainDataWriter(outputStream);
+                case CSV     : return new CSVDataWriter(outputStream);
+                case CSV_TS  : return new CSVTSDataWriter(outputStream);
+                case SIMPLE  : return new SimpleGcWriter(outputStream);
+                case SUMMARY : return new SummaryDataWriter(outputStream, configuration);
+                case PNG     : return new PNGDataWriter(outputStream, configuration);
+                default : throw new IOException(LocalisationHelper.getString("datawriterfactory_instantiation_failed") + " " + file);
+            }
         }
     }
 


### PR DESCRIPTION
getDataWriter is close — The resource opened there can leak if getDataWriter exits on an error path. this patch moves the allocation into try-with-resources so cleanup happens on every exit path. Happy to drop this if it doesn’t fit.

Happy to revise the approach or close this if it doesn’t fit — you know the codebase far better than I do.